### PR TITLE
Fix build: add forward declaration for lookup_kernel_name

### DIFF
--- a/src/hsa_intercept.cpp
+++ b/src/hsa_intercept.cpp
@@ -62,6 +62,9 @@ static std::unordered_map<uint64_t, QueueInfo> g_queue_map;  // keyed by hsa_que
 static std::atomic<uint64_t> g_dispatch_id{0};
 
 // ---- Completion worker ----
+// Forward declarations
+static std::string lookup_kernel_name(uint64_t kernel_object);
+
 // Single thread processes all completed dispatches. Replaces thread-per-dispatch.
 
 struct DispatchData {


### PR DESCRIPTION
## Summary
`completion_worker()` calls `lookup_kernel_name()` before its definition, causing build failure on ROCm container. Added forward declaration.

## Root cause
PR #14 reordered functions in hsa_intercept.cpp but missed the forward declaration. This was caught by the GPU stress test **after** merge — reinforcing why GPU build+test must happen before merge.

## Test plan
- [x] Builds clean on MI300X ROCm container
- [x] 70 non-GPU tests pass
- [x] GPU stress test: 8 GPU × 8 streams × 100 dispatches = 6528 ops, zero errors
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)