### PR TITLE
Fix wheel platform tag to manylinux_2_28_x86_64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+"""Custom setup to force platform-specific wheel tag.
+
+librpd_lite.so is Linux x86_64 only. Without this, setuptools
+produces py3-none-any which is incorrect.
+"""
+from setuptools import setup
+from wheel.bdist_wheel import bdist_wheel
+
+
+class PlatformWheel(bdist_wheel):
+    """Force platform tag to linux_x86_64 (not 'any')."""
+    def finalize_options(self):
+        super().finalize_options()
+        self.root_is_pure = False
+
+    def get_tag(self):
+        return "py3", "none", "manylinux_2_28_x86_64"
+
+
+setup(cmdclass={"bdist_wheel": PlatformWheel})


### PR DESCRIPTION
## Summary
Wheel was tagged `py3-none-any` but contains `librpd_lite.so` (Linux x86_64 only). Custom `bdist_wheel` forces `py3-none-manylinux_2_28_x86_64`.

## Test plan
- [x] 104 tests pass
- [x] ruff clean
- [ ] CI passes
- [ ] Re-tag v0.1.1 to verify correct wheel filename after merge