### PR TITLE
Fix GPT-5.4 review issues from PR #28: merge robustness

### DIFF
--- a/rocm_trace_lite/cmd_trace.py
+++ b/rocm_trace_lite/cmd_trace.py
@@ -28,12 +28,17 @@ def run_trace(args):
     # Clean stale per-process files (only those matching our PID pattern)
     import re
     for f in glob.glob(os.path.join(trace_dir, f"{trace_base}_*.db")):
-        # Only remove files matching trace_base_DIGITS.db (PID pattern)
         basename = os.path.basename(f)
         if re.match(rf"^{re.escape(trace_base)}_\d+\.db$", basename):
-            os.remove(f)
+            try:
+                os.remove(f)
+            except OSError:
+                pass
     if os.path.exists(output) and os.path.isfile(output):
-        os.remove(output)
+        try:
+            os.remove(output)
+        except OSError:
+            pass
 
     result = subprocess.run(cmd, env=env)
 
@@ -48,15 +53,20 @@ def run_trace(args):
         print("Warning: no trace files produced", file=sys.stderr)
         sys.exit(result.returncode)
 
+    import shutil
     if len(per_process_files) == 1:
-        # Single process — just rename
-        os.rename(per_process_files[0], output)
+        # Single process — move to final output
+        shutil.move(per_process_files[0], output)
     else:
         # Multi-process — merge all into one
         _merge_traces(per_process_files, output)
-        # Clean up per-process files
+        # Clean up per-process files (best-effort)
         for f in per_process_files:
-            os.remove(f)
+            try:
+                if os.path.exists(f):
+                    os.remove(f)
+            except OSError:
+                pass
 
     # Generate all output artifacts from one command
     base = os.path.splitext(output)[0]
@@ -86,60 +96,85 @@ def run_trace(args):
 
 
 def _checkpoint_wal(db_path):
-    """Checkpoint WAL journal to ensure all data is in the main DB file."""
+    """Checkpoint WAL journal and convert to DELETE mode for clean ATTACH."""
     try:
         c = sqlite3.connect(db_path)
         c.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        c.execute("PRAGMA journal_mode=DELETE")
+        c.commit()
         c.close()
-    except sqlite3.OperationalError:
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
         pass
 
 
 def _merge_traces(input_files, output_path):
-    """Merge multiple per-process RPD trace files into one."""
+    """Merge multiple per-process RPD trace files into one.
+
+    Reads rows from each source DB and inserts into the output.
+    No ATTACH needed — avoids SQLite version compatibility issues.
+    """
+    import shutil
+
     # Use the largest file as the base (likely the main ModelRunner)
     input_files.sort(key=lambda f: os.path.getsize(f), reverse=True)
 
-    # Copy the largest as the base
-    import shutil
     _checkpoint_wal(input_files[0])
-    shutil.copy2(input_files[0], output_path)
+    shutil.move(input_files[0], output_path)
 
-    conn = sqlite3.connect(output_path)
     merged_ops = 0
+    merged_count = 0
 
-    for idx, src_file in enumerate(input_files[1:]):
-        alias = f"src{idx}"
+    dst = sqlite3.connect(output_path)
+
+    for src_file in input_files[1:]:
         try:
             _checkpoint_wal(src_file)
-            # Path is internally generated (not user input), but sanitize for safety
-            safe_path = src_file.replace("'", "''")
-            conn.execute(f"ATTACH DATABASE '{safe_path}' AS {alias}")
-            src_ops = conn.execute(f"SELECT count(*) FROM {alias}.rocpd_op").fetchone()[0]
-            if src_ops == 0:
-                conn.execute(f"DETACH DATABASE {alias}")
-                continue
-            conn.execute(f"INSERT OR IGNORE INTO rocpd_string(string) SELECT string FROM {alias}.rocpd_string")
-            count = conn.execute(f"""
-                INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, description_id, opType_id)
-                SELECT o.gpuId, o.queueId, o.sequenceId, o.start, o.end,
-                    (SELECT id FROM rocpd_string WHERE string = (SELECT string FROM {alias}.rocpd_string WHERE id = o.description_id)),
-                    (SELECT id FROM rocpd_string WHERE string = (SELECT string FROM {alias}.rocpd_string WHERE id = o.opType_id))
-                FROM {alias}.rocpd_op o
-            """).rowcount
-            merged_ops += count
+
+            src = sqlite3.connect(src_file)
             try:
-                conn.execute(f"DETACH DATABASE {alias}")
+                # Read source strings and ops
+                src_strings = src.execute("SELECT string FROM rocpd_string").fetchall()
+                src_ops = src.execute(
+                    "SELECT o.gpuId, o.queueId, o.sequenceId, o.start, o.end, "
+                    "s.string AS desc_str, ot.string AS type_str "
+                    "FROM rocpd_op o "
+                    "JOIN rocpd_string s ON o.description_id = s.id "
+                    "JOIN rocpd_string ot ON o.opType_id = ot.id"
+                ).fetchall()
             except sqlite3.OperationalError:
-                pass  # DETACH may fail on some SQLite versions, data already merged
-        except sqlite3.OperationalError as e:
+                src_ops = []
+                src_strings = []
+            finally:
+                src.close()
+
+            if not src_ops:
+                continue
+
+            # Insert strings (dedup via OR IGNORE)
+            for (s,) in src_strings:
+                dst.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", (s,))
+
+            # Insert ops with string remapping
+            for gpuId, queueId, seqId, start, end, desc, optype in src_ops:
+                dst.execute(
+                    "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, "
+                    "description_id, opType_id) VALUES(?,?,?,?,?,"
+                    "(SELECT id FROM rocpd_string WHERE string=?),"
+                    "(SELECT id FROM rocpd_string WHERE string=?))",
+                    (gpuId, queueId, seqId, start, end, desc, optype))
+
+            merged_ops += len(src_ops)
+            merged_count += 1
+
+        except (sqlite3.OperationalError, OSError) as e:
             print(f"Warning: could not merge {src_file}: {e}", file=sys.stderr)
 
-    conn.commit()
-    conn.close()
+    dst.commit()
+    dst.close()
 
-    if merged_ops > 0:
-        print(f"Merged {len(input_files)} process traces ({merged_ops} additional ops)", file=sys.stderr)
+    if merged_count > 0:
+        print(f"Merged {merged_count + 1} process traces ({merged_ops} additional ops)",
+              file=sys.stderr)
 
 
 def _generate_summary(db_path):


### PR DESCRIPTION
## Summary
Addresses all 6 NEEDS CHANGES issues from GPT-5.4 review on PR #28.

## Changes
1. **No more ATTACH** — switched to read-then-insert strategy, eliminating:
   - SQL injection risk (f-string ATTACH path)
   - DETACH accumulation ("too many attached databases")
   - SQLite 3.22 ATTACH bug ("database src is locked")
2. **shutil.move** instead of os.rename (cross-filesystem safe)
3. **try/except on all file ops** (remove, cleanup)
4. **WAL checkpoint + DELETE mode** conversion before merge

## Test results
- [x] 110 non-GPU tests pass (including 7 merge tests)
- [x] ruff clean
- [x] Merge tested with SQLite 3.22 (Ubuntu 18.04)
- [ ] CI passes
- [ ] GPT-5.4 review