### PR TITLE
Expand comparison table to 5 profiling tools and fix RPD reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-contained GPU kernel profiler for ROCm. **Zero roctracer/rocprofiler-sdk de
 
 ## What it does
 
-Captures GPU kernel dispatch timestamps using only HSA runtime interception (`HSA_TOOLS_LIB`), writing to a standard SQLite `.db` file.
+A streamlined, lightweight GPU kernel profiler. Captures dispatch timestamps using only HSA runtime interception (`HSA_TOOLS_LIB`), writing to a standard SQLite `.db` file. No dependency on HIP, roctracer, or rocprofiler-sdk.
 
 ### Comparison with other ROCm profiling tools
 


### PR DESCRIPTION
## Summary
- Replace 2-column comparison (rocm-trace-lite vs RPD) with a comprehensive 5-tool table covering RPD, rocprofiler-sdk, roctracer, and Triton Proton across 10 dimensions
- Fix "standard RPD format" → "standard rocmProfileData schema" to avoid confusing the format name with the tool name
- Add "Works without profiler stack" row — the key differentiator for day-0 hardware bring-up

## Test plan
- [ ] README renders correctly on GitHub (wide table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)