### PR TITLE
Sprint 1: Add 38 CPU-only unit tests for test coverage (#30)

### DIFF
--- a/rocm_trace_lite/cmd_trace.py
+++ b/rocm_trace_lite/cmd_trace.py
@@ -314,7 +314,7 @@ def _merge_traces(input_files, output_path):
             merged_ops += len(op_rows)
             merged_count += 1
 
-        except (sqlite3.OperationalError, OSError) as e:
+        except (sqlite3.DatabaseError, OSError) as e:
             print(f"Warning: could not merge {src_file}: {e}", file=sys.stderr)
             try:
                 dst.execute("ROLLBACK")

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -1,0 +1,296 @@
+"""Boundary condition and edge-case tests for rocm-trace-lite.
+
+All tests are CPU-only. No GPU required.
+"""
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+sys.path.insert(0, os.path.join(REPO_ROOT, "tests"))
+from conftest import SCHEMA_SQL  # noqa: E402
+
+
+def _run_cli(*args):
+    r = subprocess.run(
+        [sys.executable, "-m", "rocm_trace_lite.cli"] + list(args),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        cwd=REPO_ROOT,
+    )
+    return r.returncode, r.stdout.decode(), r.stderr.decode()
+
+
+# ---------------------------------------------------------------------------
+# CLI Boundary Tests
+# ---------------------------------------------------------------------------
+
+class TestCLIBoundary:
+
+    def test_unknown_subcommand(self):
+        rc, out, err = _run_cli("badcmd")
+        assert rc != 0
+
+    def test_no_args_prints_help(self):
+        rc, out, err = _run_cli()
+        assert rc != 0
+        assert "trace" in out or "usage" in out.lower()
+
+    def test_trace_no_command(self):
+        rc, out, err = _run_cli("trace")
+        assert rc != 0
+        assert "no command" in err.lower() or "error" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# get_lib_path() Tests
+# ---------------------------------------------------------------------------
+
+class TestGetLibPath:
+
+    def test_package_local_lib(self, tmp_path):
+        fake_pkg = str(tmp_path / "pkg")
+        os.makedirs(os.path.join(fake_pkg, "lib"))
+        so_path = os.path.join(fake_pkg, "lib", "librpd_lite.so")
+        with open(so_path, "w") as f:
+            f.write("")
+
+        original_abspath = os.path.abspath
+
+        def fake_abspath(p):
+            if p.endswith("__init__.py") or p == os.path.join(fake_pkg, "__init__.py"):
+                return os.path.join(fake_pkg, "__init__.py")
+            return original_abspath(p)
+
+        # get_lib_path calls os.path.abspath(__file__) then os.path.dirname
+        # We need __file__ resolution to point to fake_pkg
+        with patch("os.path.abspath", side_effect=fake_abspath):
+            from rocm_trace_lite import get_lib_path
+            result = get_lib_path()
+        assert result == so_path
+
+    def test_fallback_usr_local_lib(self, tmp_path):
+        fake_pkg = str(tmp_path / "pkg")
+        os.makedirs(fake_pkg)
+
+        original_isfile = os.path.isfile
+        original_abspath = os.path.abspath
+
+        def fake_abspath(p):
+            if p.endswith("__init__.py"):
+                return os.path.join(fake_pkg, "__init__.py")
+            return original_abspath(p)
+
+        def fake_isfile(p):
+            if p == os.path.join(fake_pkg, "lib", "librpd_lite.so"):
+                return False
+            if p == "/usr/local/lib/librpd_lite.so":
+                return True
+            return original_isfile(p)
+
+        with patch("os.path.abspath", side_effect=fake_abspath):
+            with patch("os.path.isfile", side_effect=fake_isfile):
+                from rocm_trace_lite import get_lib_path
+                result = get_lib_path()
+        assert result == "/usr/local/lib/librpd_lite.so"
+
+    def test_not_found_raises(self, tmp_path):
+        fake_pkg = str(tmp_path / "pkg")
+        os.makedirs(fake_pkg)
+
+        original_abspath = os.path.abspath
+
+        def fake_abspath(p):
+            if p.endswith("__init__.py"):
+                return os.path.join(fake_pkg, "__init__.py")
+            return original_abspath(p)
+
+        with patch("os.path.abspath", side_effect=fake_abspath):
+            with patch("os.path.isfile", return_value=False):
+                from rocm_trace_lite import get_lib_path
+                with pytest.raises(FileNotFoundError):
+                    get_lib_path()
+
+
+# ---------------------------------------------------------------------------
+# cmd_info Edge Cases
+# ---------------------------------------------------------------------------
+
+class TestInfoEdge:
+
+    def test_empty_db(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        conn = sqlite3.connect(db)
+        conn.executescript(SCHEMA_SQL)
+        conn.close()
+        rc, out, err = _run_cli("info", db)
+        assert rc == 0
+        assert "rocpd_op: 0 rows" in out
+
+    def test_missing_file(self):
+        rc, out, err = _run_cli("info", "/tmp/_rtl_nonexistent_boundary_test.db")
+        assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# cmd_summary Edge Cases
+# ---------------------------------------------------------------------------
+
+class TestSummaryEdge:
+
+    def test_empty_trace(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        conn = sqlite3.connect(db)
+        conn.executescript(SCHEMA_SQL)
+        conn.close()
+        rc, out, err = _run_cli("summary", db)
+        assert rc == 0
+        assert "0" in out
+
+    def test_missing_file(self):
+        rc, out, err = _run_cli("summary", "/tmp/_rtl_nonexistent_boundary_test.db")
+        assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# record_copy Synthetic Tests
+# ---------------------------------------------------------------------------
+
+class TestRecordCopy:
+
+    def _make_copy_db(self, path):
+        conn = sqlite3.connect(path)
+        conn.executescript(SCHEMA_SQL)
+        conn.execute(
+            "INSERT INTO rocpd_string(id, string) VALUES(1, 'CopyDeviceToDevice')"
+        )
+        conn.execute(
+            "INSERT INTO rocpd_string(id, string) VALUES(2, 'memcpy_H2D')"
+        )
+        conn.execute(
+            "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, "
+            "description_id, opType_id) VALUES(0, 0, 0, 1000, 2000, 2, 1)"
+        )
+        conn.commit()
+        return conn
+
+    def test_copy_record_queryable(self, tmp_path):
+        db = str(tmp_path / "copy.db")
+        conn = self._make_copy_db(db)
+        rows = conn.execute(
+            "SELECT s.string FROM rocpd_op o "
+            "JOIN rocpd_string s ON o.opType_id = s.id"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "CopyDeviceToDevice"
+
+    def test_copy_not_in_kernel_top_view(self, tmp_path):
+        db = str(tmp_path / "copy.db")
+        conn = self._make_copy_db(db)
+        conn.execute(
+            "INSERT INTO rocpd_string(id, string) VALUES(3, 'KernelExecution')"
+        )
+        conn.execute(
+            "INSERT INTO rocpd_string(id, string) VALUES(4, 'my_kernel.kd')"
+        )
+        conn.execute(
+            "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, "
+            "description_id, opType_id) VALUES(0, 0, 0, 3000, 5000, 4, 3)"
+        )
+        conn.commit()
+        top_rows = conn.execute("SELECT Name FROM top").fetchall()
+        names = [r[0] for r in top_rows]
+        conn.close()
+        assert "my_kernel.kd" in names
+
+
+# ---------------------------------------------------------------------------
+# HIP API Converter Path Tests
+# ---------------------------------------------------------------------------
+
+class TestHIPAPIConvert:
+
+    def _make_api_db(self, path, add_ops=False, add_apis=False):
+        conn = sqlite3.connect(path)
+        conn.executescript(SCHEMA_SQL)
+
+        sid = 1
+        if add_ops:
+            conn.execute(
+                "INSERT INTO rocpd_string(id, string) VALUES(?, 'KernelExecution')",
+                (sid,),
+            )
+            sid += 1
+            conn.execute(
+                "INSERT INTO rocpd_string(id, string) VALUES(?, 'gemm_kernel.kd')",
+                (sid,),
+            )
+            desc_id = sid
+            sid += 1
+            conn.execute(
+                "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, "
+                "description_id, opType_id) VALUES(0, 0, 0, 1000, 2000, ?, 1)",
+                (desc_id,),
+            )
+
+        if add_apis:
+            conn.execute(
+                "INSERT INTO rocpd_string(id, string) VALUES(?, 'hipLaunchKernel')",
+                (sid,),
+            )
+            api_name_id = sid
+            sid += 1
+            conn.execute(
+                "INSERT INTO rocpd_string(id, string) VALUES(?, 'args=...')",
+                (sid,),
+            )
+            args_id = sid
+            sid += 1
+            conn.execute(
+                "INSERT INTO rocpd_api(pid, tid, start, end, apiName_id, args_id) "
+                "VALUES(1234, 5678, 500, 900, ?, ?)",
+                (api_name_id, args_id),
+            )
+
+        conn.commit()
+        conn.close()
+
+    def test_api_records_in_json(self, tmp_path):
+        db = str(tmp_path / "api.db")
+        json_out = str(tmp_path / "api.json")
+        self._make_api_db(db, add_ops=True, add_apis=True)
+        rc, out, err = _run_cli("convert", db, "-o", json_out)
+        assert rc == 0
+        with open(json_out) as f:
+            trace = json.load(f)
+        cats = [e.get("cat") for e in trace["traceEvents"]]
+        assert "hip_api" in cats
+
+    def test_empty_api_no_crash(self, tmp_path):
+        db = str(tmp_path / "noapi.db")
+        json_out = str(tmp_path / "noapi.json")
+        self._make_api_db(db, add_ops=True, add_apis=False)
+        rc, out, err = _run_cli("convert", db, "-o", json_out)
+        assert rc == 0
+        with open(json_out) as f:
+            trace = json.load(f)
+        cats = [e.get("cat") for e in trace["traceEvents"]]
+        assert "hip_api" not in cats
+
+    def test_mixed_ops_and_api(self, tmp_path):
+        db = str(tmp_path / "mixed.db")
+        json_out = str(tmp_path / "mixed.json")
+        self._make_api_db(db, add_ops=True, add_apis=True)
+        rc, out, err = _run_cli("convert", db, "-o", json_out)
+        assert rc == 0
+        with open(json_out) as f:
+            trace = json.load(f)
+        cats = [e.get("cat") for e in trace["traceEvents"]]
+        assert "hip_api" in cats
+        assert "KernelExecution" in cats

--- a/tests/test_roctx_boundary.py
+++ b/tests/test_roctx_boundary.py
@@ -1,0 +1,281 @@
+"""Roctx boundary conditions, symbol export guard, converter consistency, kernel name fallback."""
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from conftest import SCHEMA_SQL, populate_synthetic_trace
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RPD2TRACE = os.path.join(REPO_ROOT, "tools", "rpd2trace.py")
+
+
+def _find_librpd_lite():
+    """Return path to librpd_lite.so or None if not found."""
+    candidates = [
+        os.path.join(REPO_ROOT, "librpd_lite.so"),
+        os.path.join(REPO_ROOT, "build", "librpd_lite.so"),
+        os.path.join(REPO_ROOT, "rocm_trace_lite", "lib", "librpd_lite.so"),
+        "/usr/local/lib/librpd_lite.so",
+    ]
+    for p in candidates:
+        if os.path.isfile(p):
+            return p
+    return None
+
+
+LIBRPD_LITE_PATH = _find_librpd_lite()
+SKIP_NO_SO = pytest.mark.skipif(
+    LIBRPD_LITE_PATH is None,
+    reason="librpd_lite.so not found (not built)",
+)
+
+
+def insert_roctx_record(conn, message, start_ns, duration_ns, correlation_id=1):
+    """Simulate what roctx_shim.cpp writes to the DB."""
+    conn.execute(
+        "INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", (message,)
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO rocpd_string(string) VALUES('UserMarker')"
+    )
+    conn.execute(
+        "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, "
+        "description_id, opType_id) VALUES(-1, 0, 0, ?, ?, "
+        "(SELECT id FROM rocpd_string WHERE string=?), "
+        "(SELECT id FROM rocpd_string WHERE string='UserMarker'))",
+        (start_ns, start_ns + duration_ns, message),
+    )
+
+
+def insert_kernel_record(conn, name, gpu_id, start_ns, duration_ns):
+    """Insert a synthetic kernel op."""
+    conn.execute(
+        "INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", (name,)
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO rocpd_string(string) VALUES('KernelExecution')"
+    )
+    conn.execute(
+        "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, "
+        "description_id, opType_id) VALUES(?, 0, 0, ?, ?, "
+        "(SELECT id FROM rocpd_string WHERE string=?), "
+        "(SELECT id FROM rocpd_string WHERE string='KernelExecution'))",
+        (gpu_id, start_ns, start_ns + duration_ns, name),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Roctx Boundary Tests
+# ---------------------------------------------------------------------------
+
+class TestRoctxBoundary:
+
+    def test_empty_message_roctx(self, tmp_rpd):
+        """Empty string message should be stored and queryable without crash."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        insert_roctx_record(conn, "", 1000000, 5000)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT s.string FROM rocpd_op o "
+            "JOIN rocpd_string s ON o.description_id = s.id"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == ""
+        conn.close()
+
+    def test_long_message_roctx(self, tmp_rpd):
+        """1000+ character message should be stored and retrieved correctly."""
+        long_msg = "A" * 1500
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        insert_roctx_record(conn, long_msg, 1000000, 5000)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT s.string FROM rocpd_op o "
+            "JOIN rocpd_string s ON o.description_id = s.id"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == long_msg
+        assert len(row[0]) == 1500
+        conn.close()
+
+    def test_roctx_not_in_top_view(self, tmp_rpd):
+        """Roctx markers (gpuId=-1) must not appear in the top view."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        insert_kernel_record(conn, "real_kernel.kd", 0, 1000000, 5000)
+        insert_roctx_record(conn, "user_marker", 1000000, 50000)
+        conn.commit()
+
+        names = [r[0] for r in conn.execute("SELECT Name FROM top").fetchall()]
+        assert "real_kernel.kd" in names
+        assert "user_marker" not in names
+        conn.close()
+
+    def test_roctx_and_kernels_coexist(self, tmp_rpd):
+        """Roctx and kernel ops coexist with correct counts."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+
+        for i in range(3):
+            insert_roctx_record(conn, "marker_{}".format(i), 1000000 + i * 100000, 5000)
+        for i in range(5):
+            insert_kernel_record(conn, "kern_{}".format(i), 0, 2000000 + i * 100000, 3000)
+        conn.commit()
+
+        total = conn.execute("SELECT count(*) FROM rocpd_op").fetchone()[0]
+        assert total == 8
+
+        roctx_count = conn.execute(
+            "SELECT count(*) FROM rocpd_op WHERE gpuId = -1"
+        ).fetchone()[0]
+        assert roctx_count == 3
+
+        kernel_count = conn.execute(
+            "SELECT count(*) FROM rocpd_op WHERE gpuId >= 0"
+        ).fetchone()[0]
+        assert kernel_count == 5
+
+        top_names = [r[0] for r in conn.execute("SELECT Name FROM top").fetchall()]
+        assert len(top_names) == 5
+        for name in top_names:
+            assert name.startswith("kern_")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Symbol Export Guard Tests
+# ---------------------------------------------------------------------------
+
+class TestSymbolExportGuard:
+
+    @SKIP_NO_SO
+    def test_roctx_symbols_exported(self):
+        """All roctx API symbols must be exported from librpd_lite.so."""
+        required = [
+            "roctxRangePushA",
+            "roctxRangePop",
+            "roctxMarkA",
+            "roctxRangeStartA",
+            "roctxRangeStop",
+            "roctxMark",
+            "roctxRangePush",
+        ]
+        result = subprocess.run(
+            ["nm", "-D", LIBRPD_LITE_PATH],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        symbols = result.stdout.decode()
+        for sym in required:
+            assert sym in symbols, "Missing exported symbol: {}".format(sym)
+
+    @SKIP_NO_SO
+    def test_onload_onunload_exported(self):
+        """OnLoad and OnUnload must be exported."""
+        result = subprocess.run(
+            ["nm", "-D", LIBRPD_LITE_PATH],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        symbols = result.stdout.decode()
+        assert "OnLoad" in symbols, "Missing OnLoad symbol"
+        assert "OnUnload" in symbols, "Missing OnUnload symbol"
+
+    @SKIP_NO_SO
+    def test_no_roctracer_rocprofiler_symbols(self):
+        """librpd_lite.so must not export roctracer_* or rocprofiler_* symbols."""
+        import re as _re
+        result = subprocess.run(
+            ["nm", "-D", LIBRPD_LITE_PATH],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        symbols = result.stdout.decode()
+        roctracer_syms = _re.findall(r"\broctracer_\w+", symbols)
+        rocprofiler_syms = _re.findall(r"\brocprofiler_\w+", symbols)
+        assert not roctracer_syms, "Found roctracer symbols: {}".format(roctracer_syms)
+        assert not rocprofiler_syms, "Found rocprofiler symbols: {}".format(rocprofiler_syms)
+
+
+# ---------------------------------------------------------------------------
+# rpd2trace.py vs cmd_convert.py Consistency
+# ---------------------------------------------------------------------------
+
+class TestConverterConsistency:
+
+    def test_same_input_same_output(self, tmp_rpd, tmp_path):
+        """rpd2trace.py and cmd_convert must produce identical JSON for the same trace."""
+        populate_synthetic_trace(tmp_rpd, num_kernels=20)
+
+        # rpd2trace.py via subprocess
+        out_rpd2trace = str(tmp_path / "rpd2trace_out.json")
+        subprocess.run(
+            [sys.executable, RPD2TRACE, tmp_rpd, out_rpd2trace],
+            check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+
+        # cmd_convert via import
+        out_cmd = str(tmp_path / "cmd_convert_out.json")
+        from rocm_trace_lite.cmd_convert import convert
+        convert(tmp_rpd, out_cmd)
+
+        with open(out_rpd2trace) as f:
+            data1 = json.load(f)
+        with open(out_cmd) as f:
+            data2 = json.load(f)
+
+        assert data1 == data2
+
+    def test_empty_trace_no_crash_both(self, tmp_rpd, tmp_path):
+        """Empty trace must not crash either converter."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        conn.close()
+
+        # rpd2trace.py
+        out1 = str(tmp_path / "rpd2trace_empty.json")
+        result = subprocess.run(
+            [sys.executable, RPD2TRACE, tmp_rpd, out1],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        assert result.returncode == 0
+
+        # cmd_convert -- should not raise
+        out2 = str(tmp_path / "cmd_convert_empty.json")
+        from rocm_trace_lite.cmd_convert import convert
+        convert(tmp_rpd, out2)
+        # Neither should crash; output file may or may not be created
+
+
+# ---------------------------------------------------------------------------
+# Kernel Name Fallback
+# ---------------------------------------------------------------------------
+
+class TestKernelNameFallback:
+
+    def test_normal_kernel_name_in_top(self, tmp_rpd):
+        """Normal kernel name should appear correctly in top view."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        insert_kernel_record(conn, "my_gemm_kernel.kd", 0, 1000000, 5000)
+        conn.commit()
+
+        names = [r[0] for r in conn.execute("SELECT Name FROM top").fetchall()]
+        assert "my_gemm_kernel.kd" in names
+        conn.close()
+
+    def test_hex_fallback_kernel_in_top(self, tmp_rpd):
+        """Hex-address kernel name like kernel_0xDEADBEEF should display in top view."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        insert_kernel_record(conn, "kernel_0xDEADBEEF", 0, 1000000, 5000)
+        conn.commit()
+
+        names = [r[0] for r in conn.execute("SELECT Name FROM top").fetchall()]
+        assert "kernel_0xDEADBEEF" in names
+        conn.close()

--- a/tests/test_trace_generation.py
+++ b/tests/test_trace_generation.py
@@ -1,0 +1,249 @@
+"""CPU-only tests for cmd_trace.py: _generate_summary, _generate_perfetto, _merge_traces, _checkpoint_wal."""
+import gzip
+import json
+import os
+import sqlite3
+
+from rocm_trace_lite.cmd_trace import (
+    _checkpoint_wal,
+    _generate_perfetto,
+    _generate_summary,
+    _merge_traces,
+)
+
+# Re-use shared schema
+from conftest import SCHEMA_SQL, populate_synthetic_trace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_empty_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA_SQL)
+    conn.close()
+    return path
+
+
+def _make_single_kernel_db(path, kernel_name="my_kernel.kd", gpu_id=0,
+                           start=1000000000, duration=5000, count=1):
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA_SQL)
+    conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", (kernel_name,))
+    conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", ("KernelExecution",))
+    for i in range(count):
+        s = start + i * 10000
+        e = s + duration
+        conn.execute(
+            "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, description_id, opType_id) "
+            "VALUES(?, 0, 0, ?, ?, "
+            "(SELECT id FROM rocpd_string WHERE string=?), "
+            "(SELECT id FROM rocpd_string WHERE string='KernelExecution'))",
+            (gpu_id, s, e, kernel_name),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+# ===========================================================================
+# _generate_summary
+# ===========================================================================
+
+class TestGenerateSummary:
+
+    def test_empty_trace(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        _make_empty_db(db)
+        result = _generate_summary(db)
+        assert result is not None
+        assert "0 GPU ops" in result
+
+    def test_single_kernel(self, tmp_path):
+        db = str(tmp_path / "single.db")
+        _make_single_kernel_db(db, kernel_name="gemm_kernel.kd", count=3)
+        result = _generate_summary(db)
+        assert "gemm_kernel.kd" in result
+        assert "3" in result  # calls count
+
+    def test_multi_gpu(self, tmp_path):
+        db = str(tmp_path / "multigpu.db")
+        populate_synthetic_trace(db, num_kernels=20, num_gpus=2)
+        result = _generate_summary(db)
+        assert "GPU 0" in result
+        assert "GPU 1" in result
+
+    def test_large_trace_top20(self, tmp_path):
+        db = str(tmp_path / "large.db")
+        conn = sqlite3.connect(db)
+        conn.executescript(SCHEMA_SQL)
+        conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", ("KernelExecution",))
+        # Create 30 distinct kernels, each with ops
+        for k in range(30):
+            name = "kernel_{:03d}.kd".format(k)
+            conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", (name,))
+            for i in range(5):
+                s = 1000000000 + k * 100000 + i * 10000
+                e = s + 5000
+                conn.execute(
+                    "INSERT INTO rocpd_op(gpuId, queueId, sequenceId, start, end, description_id, opType_id) "
+                    "VALUES(0, 0, 0, ?, ?, "
+                    "(SELECT id FROM rocpd_string WHERE string=?), "
+                    "(SELECT id FROM rocpd_string WHERE string='KernelExecution'))",
+                    (s, e, name),
+                )
+        conn.commit()
+        conn.close()
+
+        result = _generate_summary(db)
+        assert result is not None
+        # top view is LIMIT 20, so at most 20 kernel lines in the table
+        # Count data lines (lines with ".kd" in them)
+        kernel_lines = [line for line in result.splitlines() if ".kd" in line]
+        assert len(kernel_lines) <= 20
+
+
+# ===========================================================================
+# _generate_perfetto
+# ===========================================================================
+
+class TestGeneratePerfetto:
+
+    def test_normal_trace(self, tmp_path):
+        db = str(tmp_path / "trace.db")
+        populate_synthetic_trace(db, num_kernels=10, num_gpus=1)
+        out = str(tmp_path / "trace.json.gz")
+        _generate_perfetto(db, out)
+        assert os.path.exists(out)
+        with gzip.open(out, "rb") as f:
+            data = json.loads(f.read())
+        assert "traceEvents" in data
+        assert len(data["traceEvents"]) > 0
+
+    def test_empty_trace(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        _make_empty_db(db)
+        out = str(tmp_path / "empty.json.gz")
+        _generate_perfetto(db, out)
+        # Empty trace: convert() prints "trace is empty" and returns without writing.
+        # _generate_perfetto catches the exception or the file may not exist.
+        # Either way, should not crash.
+
+    def test_output_path_nonexistent_dir(self, tmp_path):
+        db = str(tmp_path / "trace.db")
+        populate_synthetic_trace(db, num_kernels=5, num_gpus=1)
+        out = str(tmp_path / "no_such_dir" / "trace.json.gz")
+        # Should not crash — the function catches exceptions
+        _generate_perfetto(db, out)
+
+
+# ===========================================================================
+# _merge_traces
+# ===========================================================================
+
+class TestMergeTraces:
+
+    def test_single_file(self, tmp_path):
+        db = str(tmp_path / "single.db")
+        populate_synthetic_trace(db, num_kernels=10, num_gpus=1)
+        out = str(tmp_path / "merged.db")
+        _merge_traces([db], out)
+        assert os.path.exists(out)
+        conn = sqlite3.connect(out)
+        count = conn.execute("SELECT count(*) FROM rocpd_op").fetchone()[0]
+        conn.close()
+        assert count == 10
+
+    def test_two_files(self, tmp_path):
+        db1 = str(tmp_path / "trace1.db")
+        db2 = str(tmp_path / "trace2.db")
+        _make_single_kernel_db(db1, kernel_name="kernel_a.kd", count=5,
+                               start=1000000000)
+        _make_single_kernel_db(db2, kernel_name="kernel_b.kd", count=3,
+                               start=2000000000)
+        out = str(tmp_path / "merged.db")
+        _merge_traces([db1, db2], out)
+        conn = sqlite3.connect(out)
+        count = conn.execute("SELECT count(*) FROM rocpd_op").fetchone()[0]
+        conn.close()
+        assert count == 8
+
+    def test_empty_source(self, tmp_path):
+        db1 = str(tmp_path / "normal.db")
+        db2 = str(tmp_path / "empty.db")
+        _make_single_kernel_db(db1, kernel_name="real_kernel.kd", count=5)
+        _make_empty_db(db2)
+        out = str(tmp_path / "merged.db")
+        _merge_traces([db1, db2], out)
+        conn = sqlite3.connect(out)
+        count = conn.execute("SELECT count(*) FROM rocpd_op").fetchone()[0]
+        conn.close()
+        assert count == 5
+
+    def test_corrupted_source(self, tmp_path):
+        db1 = str(tmp_path / "normal.db")
+        bad = str(tmp_path / "corrupted.db")
+        _make_single_kernel_db(db1, kernel_name="good_kernel.kd", count=5)
+        with open(bad, "w") as f:
+            f.write("this is not a sqlite file")
+        out = str(tmp_path / "merged.db")
+        _merge_traces([db1, bad], out)
+        conn = sqlite3.connect(out)
+        count = conn.execute("SELECT count(*) FROM rocpd_op").fetchone()[0]
+        conn.close()
+        assert count == 5
+
+    def test_string_dedup(self, tmp_path):
+        db1 = str(tmp_path / "a.db")
+        db2 = str(tmp_path / "b.db")
+        shared_name = "shared_kernel.kd"
+        _make_single_kernel_db(db1, kernel_name=shared_name, count=2,
+                               start=1000000000)
+        _make_single_kernel_db(db2, kernel_name=shared_name, count=3,
+                               start=2000000000)
+        out = str(tmp_path / "merged.db")
+        _merge_traces([db1, db2], out)
+        conn = sqlite3.connect(out)
+        dup_count = conn.execute(
+            "SELECT count(*) FROM rocpd_string WHERE string=?", (shared_name,)
+        ).fetchone()[0]
+        ops = conn.execute("SELECT count(*) FROM rocpd_op").fetchone()[0]
+        conn.close()
+        assert dup_count == 1
+        assert ops == 5
+
+
+# ===========================================================================
+# _checkpoint_wal
+# ===========================================================================
+
+class TestCheckpointWal:
+
+    def test_wal_mode_db(self, tmp_path):
+        db = str(tmp_path / "wal.db")
+        conn = sqlite3.connect(db)
+        conn.executescript(SCHEMA_SQL)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("INSERT INTO rocpd_string(string) VALUES('test')")
+        conn.commit()
+        conn.close()
+
+        _checkpoint_wal(db)
+
+        conn = sqlite3.connect(db)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode == "delete"
+
+    def test_nonexistent_db(self, tmp_path):
+        db = str(tmp_path / "does_not_exist.db")
+        # Should not crash
+        _checkpoint_wal(db)
+
+    def test_corrupted_db(self, tmp_path):
+        bad = str(tmp_path / "corrupted.db")
+        with open(bad, "w") as f:
+            f.write("not a database")
+        # Should not crash
+        _checkpoint_wal(bad)


### PR DESCRIPTION
## Summary
Sprint 1 of 5 for test coverage improvement (issue #30). Adds **38 new CPU-only tests** across 3 new test files, plus a bug fix found during testing.

## New Tests

| File | Tests | Coverage |
|------|-------|---------|
| `test_trace_generation.py` | 15 | `_generate_summary`, `_generate_perfetto`, `_merge_traces`, `_checkpoint_wal` |
| `test_boundary.py` | 15 | CLI edge cases, `get_lib_path`, `cmd_info`/`cmd_summary` empty/missing, `record_copy`, HIP API converter |
| `test_roctx_boundary.py` | 8+3 skip | roctx empty/long message, symbol export guard, rpd2trace vs cmd_convert consistency, kernel name fallback |

## Bug Fix
- `cmd_trace.py:317`: `_merge_traces` caught `OperationalError` but missed `DatabaseError` (parent class). Corrupt trace files throwing "file is not a database" were not caught gracefully.

## Results
- **Before**: 130 passed, 29 skipped
- **After**: 168 passed, 32 skipped (+38 new, +3 skip for symbol tests without .so)
- Lint clean, runtime ~24s

## Test plan
- [x] `ruff check` — all clean
- [x] `pytest tests/` — 168 passed, 0 failures
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)