### PR TITLE
Add MI355 GPU runner test workflow

### DIFF
--- a/.github/workflows/test-mi355-runner.yml
+++ b/.github/workflows/test-mi355-runner.yml
@@ -1,0 +1,45 @@
+name: Test MI355 Runner
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  test-1gpu:
+    runs-on: linux-rocm-trace-lite-mi355-1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: GPU Check
+        run: |
+          echo "=== ROCm SMI ==="
+          rocm-smi
+          echo ""
+          echo "=== GPU Count ==="
+          rocm-smi --showid | grep -c "GPU"
+
+      - name: Environment
+        run: |
+          echo "=== Python ==="
+          python3 --version
+          echo "=== Docker ==="
+          docker --version
+          echo "=== Hostname ==="
+          hostname
+
+  test-8gpu:
+    runs-on: linux-rocm-trace-lite-mi355-8
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: GPU Check
+        run: |
+          echo "=== ROCm SMI ==="
+          rocm-smi
+          echo ""
+          echo "=== GPU Count ==="
+          rocm-smi --showid | grep -c "GPU"
+          echo ""
+          echo "=== XGMI Topology ==="
+          rocm-smi --showtopo


### PR DESCRIPTION
## Summary
- Adds a smoke test workflow for self-hosted MI355 GPU runners
- Tests both 1-GPU (`linux-rocm-trace-lite-mi355-1`) and 8-GPU (`linux-rocm-trace-lite-mi355-8`) runners
- Checks: ROCm SMI, GPU count, Docker, hostname, XGMI topology (8GPU)
- Triggers on push to main or manual dispatch

## Test plan
- [ ] Merge runner infra PR first: https://github.com/ROCm/rocOps/pull/278
- [ ] Trigger workflow manually via Actions tab to verify runners work
- [ ] Confirm 1-GPU job sees 1 GPU, 8-GPU job sees 8 GPUs