### PR TITLE
Sprint 2: Add 30 single-dimension GPU E2E tests (#30)

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -4,7 +4,7 @@ Covers SQLite error paths, rpd_lite.sh validation, converter consistency,
 shutdown ordering, completion worker diagnostics, extended source guards,
 CI workflow validation, and arch-specific GPU tracing.
 
-CPU-only tests run without any GPU or librpd_lite.so.
+CPU-only tests run without any GPU or librtl.so.
 GPU tests are skipped when no ROCm GPU is available.
 """
 import json
@@ -35,7 +35,7 @@ from rocm_trace_lite.cmd_trace import (  # noqa: E402
 
 SRC_DIR = os.path.join(REPO_ROOT, "src")
 TOOLS_DIR = os.path.join(REPO_ROOT, "tools")
-LIB_PATH = os.path.join(REPO_ROOT, "librpd_lite.so")
+LIB_PATH = os.path.join(REPO_ROOT, "librtl.so")
 
 
 # ---------------------------------------------------------------------------
@@ -43,15 +43,8 @@ LIB_PATH = os.path.join(REPO_ROOT, "librpd_lite.so")
 # ---------------------------------------------------------------------------
 
 def _has_gpu():
-    """Check if ROCm GPU is available via torch."""
-    try:
-        r = subprocess.run(
-            [sys.executable, "-c", "import torch; assert torch.cuda.is_available()"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30,
-        )
-        return r.returncode == 0
-    except Exception:
-        return False
+    from conftest import _rocm_gpu_available
+    return _rocm_gpu_available()
 
 
 def _has_lib():
@@ -149,7 +142,7 @@ class TestRpdLiteShell:
         sh_dst = str(tmp_path / "rpd_lite.sh")
         shutil.copy2(sh_src, sh_dst)
         # rpd_lite.sh resolves LIB from SCRIPT_DIR, so place dummy .so there
-        fake_lib = str(tmp_path / "librpd_lite.so")
+        fake_lib = str(tmp_path / "librtl.so")
         with open(fake_lib, "w") as f:
             f.write("")
         return sh_dst
@@ -291,7 +284,7 @@ class TestConverterConsistency:
 class TestShutdownOrdering:
     """Verify trace completeness after workload shutdown."""
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_normal_workload_complete_trace(self, tmp_path):
         """Normal workload should produce a complete trace (no truncation)."""
         trace = str(tmp_path / "shutdown.db")
@@ -311,7 +304,7 @@ class TestShutdownOrdering:
         # 50 matmuls should produce at least some ops
         assert ops >= 10, "Expected >= 10 ops, got {}".format(ops)
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_short_workload_flush_completes(self, tmp_path):
         """Very short workload (< 100ms) should still flush completely."""
         trace = str(tmp_path / "short.db")
@@ -338,7 +331,7 @@ class TestShutdownOrdering:
 class TestCompletionWorkerDiagnostics:
     """Verify diagnostic output from the completion worker."""
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_stderr_contains_finalized(self, tmp_path):
         """Normal workload stderr should contain trace finalized message."""
         trace = str(tmp_path / "diag.db")
@@ -364,7 +357,7 @@ class TestCompletionWorkerDiagnostics:
             "Expected diagnostic output in stderr, got: {}".format(stderr[:500])
         )
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_records_written_format(self, tmp_path):
         """Diagnostic output should include record count information."""
         trace = str(tmp_path / "diag2.db")
@@ -509,7 +502,7 @@ class TestCIWorkflow:
 class TestArchSpecific:
     """Arch-specific GPU tracing tests."""
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_detect_gpu_arch_and_trace(self, tmp_path):
         """Detect current GPU arch and verify tracing works."""
         trace = str(tmp_path / "arch.db")
@@ -529,7 +522,7 @@ class TestArchSpecific:
         conn.close()
         assert ops >= 1, "Expected >= 1 op, got {}".format(ops)
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_gpu_id_reasonable(self, tmp_path):
         """gpuId in trace should be >= 0."""
         trace = str(tmp_path / "gpuid.db")
@@ -556,7 +549,7 @@ class TestArchSpecific:
         # neg_count is informational (roctx markers use gpuId=-1)
         assert total >= 1, "No ops with gpuId >= 0 (neg_count={})".format(neg_count)
 
-    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librpd_lite.so")
+    @pytest.mark.skipif(not HAS_GPU, reason="No GPU or librtl.so")
     def test_fallback_detection_stderr(self, tmp_path):
         """If running on gfx1250 or similar, check for fallback info in stderr."""
         trace = str(tmp_path / "fallback.db")

--- a/tests/test_gpu_combo.py
+++ b/tests/test_gpu_combo.py
@@ -16,19 +16,12 @@ import sys
 import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-LIB_PATH = os.path.join(REPO_ROOT, "librpd_lite.so")
+LIB_PATH = os.path.join(REPO_ROOT, "librtl.so")
 
 
 def _has_gpu():
-    """Check if ROCm GPU is available."""
-    try:
-        r = subprocess.run(
-            [sys.executable, "-c", "import torch; assert torch.cuda.is_available()"],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30,
-        )
-        return r.returncode == 0
-    except Exception:
-        return False
+    from conftest import _rocm_gpu_available
+    return _rocm_gpu_available()
 
 
 def _gpu_count():

--- a/tests/test_gpu_single_dim.py
+++ b/tests/test_gpu_single_dim.py
@@ -14,21 +14,9 @@ import textwrap
 
 import pytest
 
-def _detect_rocm_gpu():
-    """Detect ROCm GPU via /dev/kfd or rocm-smi, independent of torch."""
-    if os.path.exists("/dev/kfd"):
-        return True
-    try:
-        result = subprocess.run(
-            ["rocm-smi", "--showid"], stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, timeout=5
-        )
-        return result.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+from conftest import _rocm_gpu_available
 
-
-HAS_GPU = _detect_rocm_gpu()
+HAS_GPU = _rocm_gpu_available()
 
 gpu = pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 
@@ -84,7 +72,7 @@ def _trace_and_connect(tmp_path, script_code, timeout=120):
 # ---------------------------------------------------------------------------
 ROCTX_PREAMBLE = '''
 import ctypes, os
-_lib = os.environ.get("HSA_TOOLS_LIB", "librpd_lite.so")
+_lib = os.environ.get("HSA_TOOLS_LIB", "librtl.so")
 _roctx = ctypes.CDLL(_lib)
 _roctx.roctxRangePushA.argtypes = [ctypes.c_char_p]
 _roctx.roctxRangePushA.restype = ctypes.c_int
@@ -765,7 +753,7 @@ class TestOtherSingleDim:
         conn = _trace_and_connect(tmp_path, """
             import ctypes, os
 
-            _lib = os.environ.get("HSA_TOOLS_LIB", "librpd_lite.so")
+            _lib = os.environ.get("HSA_TOOLS_LIB", "librtl.so")
             try:
                 _rtl = ctypes.CDLL(_lib)
                 _rtl.tick.restype = ctypes.c_uint64
@@ -794,7 +782,7 @@ class TestOtherSingleDim:
         conn = _trace_and_connect(tmp_path, """
             import ctypes, os
 
-            _lib = os.environ.get("HSA_TOOLS_LIB", "librpd_lite.so")
+            _lib = os.environ.get("HSA_TOOLS_LIB", "librtl.so")
             try:
                 _rtl = ctypes.CDLL(_lib)
                 _rtl.getCorrelationId.restype = ctypes.c_uint64

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -21,7 +21,7 @@ from conftest import populate_synthetic_trace
 from rocm_trace_lite.cmd_trace import _generate_summary
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-LIB_PATH = os.path.join(REPO_ROOT, "librpd_lite.so")
+LIB_PATH = os.path.join(REPO_ROOT, "librtl.so")
 
 try:
     import torch
@@ -38,7 +38,7 @@ def _has_lib():
 
 def _skip_if_no_gpu():
     if not HAS_GPU or not _has_lib():
-        pytest.skip("No GPU or librpd_lite.so not built")
+        pytest.skip("No GPU or librtl.so not built")
 
 
 def _run_traced(script, trace_path, timeout=120):
@@ -81,12 +81,12 @@ def _make_valid_db(path, num_kernels=10):
 
 
 class TestHSALifecycle:
-    """Verify librpd_lite.so symbols and dependencies."""
+    """Verify librtl.so symbols and dependencies."""
 
     def test_onload_onunload_symbols(self):
-        """dlopen librpd_lite.so (if exists), verify OnLoad/OnUnload symbols via nm -D."""
+        """dlopen librtl.so (if exists), verify OnLoad/OnUnload symbols via nm -D."""
         if not _has_lib():
-            pytest.skip("librpd_lite.so not built")
+            pytest.skip("librtl.so not built")
 
         result = subprocess.run(
             ["nm", "-D", LIB_PATH],
@@ -96,13 +96,13 @@ class TestHSALifecycle:
         assert result.returncode == 0, "nm -D failed: {}".format(result.stderr)
         symbols = result.stdout
 
-        assert "OnLoad" in symbols, "OnLoad symbol not exported in librpd_lite.so"
-        assert "OnUnload" in symbols, "OnUnload symbol not exported in librpd_lite.so"
+        assert "OnLoad" in symbols, "OnLoad symbol not exported in librtl.so"
+        assert "OnUnload" in symbols, "OnUnload symbol not exported in librtl.so"
 
     def test_shared_lib_dependencies(self):
         """Verify .so NEEDED dependencies are only expected libraries."""
         if not _has_lib():
-            pytest.skip("librpd_lite.so not built")
+            pytest.skip("librtl.so not built")
 
         result = subprocess.run(
             ["ldd", LIB_PATH],


### PR DESCRIPTION
## Summary
Sprint 2 of 5 for test coverage (issue #30). **30 GPU E2E tests** covering multi-thread, multi-stream, HIP Graph, roctx, and other single-dimension scenarios.

Requires `linux-rocm-trace-lite-mi355-1` runner for CI validation.

## Test plan
- [x] Lint clean
- [x] 184 passed, 0 failed on CPU (30 GPU tests correctly skipped)
- [ ] GPU validation on MI355X runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)