### PR TITLE
Sprint 3: Add 35 combination-dimension GPU E2E tests (#30)

### DIFF
--- a/tests/test_gpu_combo.py
+++ b/tests/test_gpu_combo.py
@@ -16,21 +16,12 @@ import sys
 import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-LIB_PATH = os.path.join(REPO_ROOT, "librpd_lite.so")
+LIB_PATH = os.path.join(REPO_ROOT, "librtl.so")
 
 
 def _has_gpu():
-    """Check if ROCm GPU is available via /dev/kfd or rocm-smi."""
-    if os.path.exists("/dev/kfd"):
-        return True
-    try:
-        r = subprocess.run(
-            ["rocm-smi", "--showid"], stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, timeout=5,
-        )
-        return r.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+    from conftest import _rocm_gpu_available
+    return _rocm_gpu_available()
 
 
 def _gpu_count():


### PR DESCRIPTION
## Summary
Sprint 3 of 5 for test coverage (issue #30). **35 GPU E2E tests** covering all cross-dimension combinations: thread × stream × GPU × graph × process.

- 9 tests `@gpu` (single GPU, `linux-rocm-trace-lite-mi355-1`)
- 26 tests `@multigpu` (2+ GPUs, `linux-rocm-trace-lite-mi355-8`)

## Test plan
- [x] Lint clean
- [x] All tests correctly skipped on non-GPU machine
- [ ] Single-GPU validation on mi355-1
- [ ] Multi-GPU validation on mi355-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)