### PR TITLE
Sprint 5: Add 11 stress and fault injection tests (#30)

### DIFF
--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -21,23 +21,11 @@ from conftest import populate_synthetic_trace
 from rocm_trace_lite.cmd_trace import _generate_summary
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-LIB_PATH = os.path.join(REPO_ROOT, "librpd_lite.so")
+LIB_PATH = os.path.join(REPO_ROOT, "librtl.so")
 
-def _detect_rocm_gpu():
-    """Detect ROCm GPU via /dev/kfd or rocm-smi, independent of torch."""
-    if os.path.exists("/dev/kfd"):
-        return True
-    try:
-        result = subprocess.run(
-            ["rocm-smi", "--showid"], stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, timeout=5
-        )
-        return result.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+from conftest import _rocm_gpu_available
 
-
-HAS_GPU = _detect_rocm_gpu()
+HAS_GPU = _rocm_gpu_available()
 
 gpu = pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 
@@ -48,7 +36,7 @@ def _has_lib():
 
 def _skip_if_no_gpu():
     if not HAS_GPU or not _has_lib():
-        pytest.skip("No GPU or librpd_lite.so not built")
+        pytest.skip("No GPU or librtl.so not built")
 
 
 def _run_traced(script, trace_path, timeout=120):
@@ -91,12 +79,12 @@ def _make_valid_db(path, num_kernels=10):
 
 
 class TestHSALifecycle:
-    """Verify librpd_lite.so symbols and dependencies."""
+    """Verify librtl.so symbols and dependencies."""
 
     def test_onload_onunload_symbols(self):
-        """dlopen librpd_lite.so (if exists), verify OnLoad/OnUnload symbols via nm -D."""
+        """dlopen librtl.so (if exists), verify OnLoad/OnUnload symbols via nm -D."""
         if not _has_lib():
-            pytest.skip("librpd_lite.so not built")
+            pytest.skip("librtl.so not built")
 
         result = subprocess.run(
             ["nm", "-D", LIB_PATH],
@@ -106,13 +94,13 @@ class TestHSALifecycle:
         assert result.returncode == 0, "nm -D failed: {}".format(result.stderr)
         symbols = result.stdout
 
-        assert "OnLoad" in symbols, "OnLoad symbol not exported in librpd_lite.so"
-        assert "OnUnload" in symbols, "OnUnload symbol not exported in librpd_lite.so"
+        assert "OnLoad" in symbols, "OnLoad symbol not exported in librtl.so"
+        assert "OnUnload" in symbols, "OnUnload symbol not exported in librtl.so"
 
     def test_shared_lib_dependencies(self):
         """Verify .so NEEDED dependencies are only expected libraries."""
         if not _has_lib():
-            pytest.skip("librpd_lite.so not built")
+            pytest.skip("librtl.so not built")
 
         result = subprocess.run(
             ["ldd", LIB_PATH],


### PR DESCRIPTION
## Summary
Sprint 5 of 5 for test coverage (issue #30). **11 tests** for stress scenarios and fault injection.

- 3 CPU tests pass immediately
- 2 skip (need librpd_lite.so build)
- 6 GPU tests need `linux-rocm-trace-lite-mi355-1`

## Test plan
- [x] Lint clean
- [x] CPU tests pass
- [ ] GPU stress tests on mi355-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)