### PR TITLE
Add GPU test CI workflow for MI355X runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           echo "PASS"
 
   python-tests:
-    name: Python tests (41 tests)
+    name: Python tests (CPU)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -1,0 +1,60 @@
+name: GPU Tests
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  gpu-single:
+    name: GPU tests (single MI355X)
+    runs-on: linux-rocm-trace-lite-mi355-1
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build librpd_lite.so
+        run: make -j$(nproc)
+
+      - name: Install test deps
+        run: pip install pytest -e .
+
+      - name: Run single-GPU tests
+        run: |
+          pytest tests/ -v --tb=short \
+            -k "not multigpu" \
+            --timeout=120 \
+            2>&1 | tee gpu-test-results.txt
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-single-results
+          path: gpu-test-results.txt
+
+  gpu-multi:
+    name: GPU tests (8x MI355X)
+    runs-on: linux-rocm-trace-lite-mi355-8
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build librpd_lite.so
+        run: make -j$(nproc)
+
+      - name: Install test deps
+        run: pip install pytest -e .
+
+      - name: Run all tests including multi-GPU
+        run: |
+          pytest tests/ -v --tb=short \
+            --timeout=180 \
+            2>&1 | tee gpu-test-results.txt
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-multi-results
+          path: gpu-test-results.txt


### PR DESCRIPTION
## Summary
Add GPU CI workflow using self-hosted MI355X runners. This needs to merge before the Sprint 2-5 test PRs so GPU tests get validated.

## New workflow: `.github/workflows/gpu-tests.yml`

| Job | Runner | Scope | Timeout |
|-----|--------|-------|---------|
| `gpu-single` | `linux-rocm-trace-lite-mi355-1` | All tests except `@multigpu` | 15 min |
| `gpu-multi` | `linux-rocm-trace-lite-mi355-8` | All tests including multi-GPU | 30 min |

Triggers: PR to main + manual dispatch.

Also renames CI test job from "41 tests" to "CPU" (test count has grown to 168+).

## Test plan
- [ ] GPU runners pick up the jobs
- [ ] Single-GPU job runs tests marked `@gpu`
- [ ] Multi-GPU job runs tests marked `@multigpu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)