### PR TITLE
docs: clarify output format is SQLite .db, not RPD format

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,7 +11,7 @@
 | **PC sampling** | No | Yes | No |
 | **roctx markers** | Built-in shim | libroctx64 | libroctx64 |
 | **Multi-GPU** | Automatic per-process merge | Manual | Manual |
-| **Output format** | RPD SQLite + Perfetto JSON | Various | RPD SQLite |
+| **Output format** | SQLite .db + Perfetto JSON | Various | RPD SQLite |
 | **Overhead** | Low (signal pool, single worker) | Medium-High | Medium |
 | **New HW bring-up** | Works immediately (HSA only) | Requires rocprofiler support | Requires roctracer support |
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ rocm-trace-lite
 Self-contained GPU kernel profiler for ROCm. **Zero roctracer/rocprofiler-sdk dependency.**
 
 Captures GPU kernel dispatch timestamps using only HSA runtime interception,
-writing to SQLite in the standard `RPD <https://github.com/ROCm/rocmProfileData>`_ format.
+writing to a standard SQLite .db file.
 One command to profile, one file to analyze.
 
 .. code-block:: bash
@@ -27,8 +27,8 @@ One command to profile, one file to analyze.
        <p>Auto-generates compressed Perfetto JSON. Open in <a href="https://ui.perfetto.dev">ui.perfetto.dev</a> for timeline visualization.</p>
      </div>
      <div class="feature-card">
-       <h3>RPD Compatible</h3>
-       <p>Outputs standard RPD SQLite schema. Works with existing RPD ecosystem tools and SQL queries.</p>
+       <h3>SQLite Output</h3>
+       <p>Outputs standard SQLite .db files. Compatible with <a href="https://github.com/ROCm/rocmProfileData">RPD</a> ecosystem tools and SQL queries.</p>
      </div>
    </div>
 

--- a/docs/output_format.md
+++ b/docs/output_format.md
@@ -1,6 +1,6 @@
 # Output Format
 
-rocm-trace-lite outputs SQLite databases compatible with the [RPD](https://github.com/ROCm/rocmProfileData) ecosystem.
+rocm-trace-lite outputs standard SQLite .db databases. The schema is compatible with [RPD](https://github.com/ROCm/rocmProfileData) ecosystem tools.
 
 ## Database schema
 


### PR DESCRIPTION
## Summary

- Fix incorrect "RPD format" references across documentation files
- The tool outputs standard SQLite `.db` files, NOT RPD format. RPD is a separate project (ROCm/rocmProfileData)
- All credit and compatibility references to RPD are preserved — only the "is RPD" wording changed to "compatible with RPD"

## Changes

- **docs/index.rst**: Hero text changed from "writing to SQLite in the standard RPD format" to "writing to a standard SQLite .db file". Feature card renamed from "RPD Compatible" to "SQLite Output" with corrected description.
- **docs/output_format.md**: Opening line clarified to "outputs standard SQLite .db databases" with RPD compatibility noted separately.
- **docs/comparison.md**: Feature table cell changed from "RPD SQLite + Perfetto JSON" to "SQLite .db + Perfetto JSON".
- **README.md**: Already correct, no changes needed.

## Test plan

- [ ] Verify Sphinx docs build without errors
- [ ] Review rendered docs to confirm RPD links still work
- [ ] Confirm "Relationship to RPD" section in comparison.md is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)