### PR TITLE
Fix 8-GPU signal pool contention: increase initial pool from 64 to 256

### DIFF
--- a/src/hsa_intercept.cpp
+++ b/src/hsa_intercept.cpp
@@ -563,9 +563,9 @@ extern "C" bool OnLoad(void* pTable,
     hsa_iterate_agents(agent_iterate_cb, nullptr);
     fprintf(stderr, "rtl: found %zu GPU agent(s)\n", g_gpu_agents.size());
 
-    // Pre-allocate signal pool
-    g_signal_pool.reserve(256);
-    for (int i = 0; i < 64; i++) {
+    // Pre-allocate signal pool (256 initial for multi-GPU workloads)
+    g_signal_pool.reserve(512);
+    for (int i = 0; i < 256; i++) {
         hsa_signal_t sig;
         if (g_orig_core.hsa_signal_create_fn(1, 0, nullptr, &sig) == HSA_STATUS_SUCCESS) {
             g_signal_pool.push_back(sig);


### PR DESCRIPTION
## Summary

- Increase initial signal pool from 64 to 256 signals
- Increase pool reserve from 256 to 512
- Fixes 8-GPU NCCL profiling regression where overhead was +451%

## Root Cause

8 processes × NCCL kernel dispatches exhausted the 64-signal pool quickly, forcing `hsa_signal_create` on the hot path. Mutex contention on `g_pool_mutex` across 8 concurrent completion_worker threads caused serialization.

## Before (pool=64, 8-GPU NCCL)
| Run | Baseline | RTL | Overhead |
|-----|----------|-----|----------|
| 1 | 0.52s | 0.51s | ~0% |
| 2 | 0.41s | 3.05s | +644% |
| 3 | 0.59s | 3.67s | +522% |
| 4 | 0.60s | 3.06s | +410% |

## After (pool=256, 8-GPU NCCL)
| Run | Baseline | RTL | Overhead |
|-----|----------|-----|----------|
| 1 | 0.398s | 0.400s | +0.5% |
| 2 | 0.364s | 0.403s | +10.7% |
| 3 | 0.420s | 0.383s | -8.8% |
| 4 | 0.395s | 0.365s | -7.6% |
| 5 | 0.394s | 0.421s | +6.9% |

Median: **+1.3% overhead** (within noise).

## Penalty assessment

- Memory: 192 extra signals × ~64 bytes = ~12KB. Negligible.
- Startup: ~192 extra `hsa_signal_create` calls = ~0.2-0.4ms one-time. Not measurable.
- Runtime: zero — unused signals sit in the pool vector.

## Test plan

- [x] 8-GPU NCCL all-reduce + all-gather: 5 runs, overhead < 5%
- [ ] Full single-GPU regression benchmark (all workloads × all profilers)
- [ ] GPU stress test before merge

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)