### PR TITLE
repro: Add ROCR interceptible queue SEGFAULT reproducer (hipGraph + HSA intercept)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.db
 tests/gpu_workload
 docs/_build/
+repro_hipgraph_stress

--- a/repro/Makefile
+++ b/repro/Makefile
@@ -1,0 +1,40 @@
+ROCM_PATH ?= /opt/rocm
+HIPCC      ?= $(ROCM_PATH)/bin/hipcc
+CXX        ?= g++
+
+HSA_INC    = $(ROCM_PATH)/include
+HSA_LIB    = $(ROCM_PATH)/lib
+
+# Number of kernels in the graph (256 is threshold for the bug)
+NUM_KERNELS ?= 256
+
+.PHONY: all clean test test-plain test-intercept
+
+all: librepro_passthrough.so repro_hipgraph_stress
+
+librepro_passthrough.so: repro_passthrough_lib.cpp
+	$(CXX) -shared -fPIC -O2 -DAMD_INTERNAL_BUILD -o $@ $< \
+		-I$(HSA_INC) -L$(HSA_LIB) -lhsa-runtime64
+
+repro_hipgraph_stress: repro_hipgraph_stress.hip
+	$(HIPCC) -O2 -DNUM_KERNELS=$(NUM_KERNELS) -o $@ $<
+
+# Run without interception (should PASS)
+test-plain: repro_hipgraph_stress
+	@echo "========================================"
+	@echo "Running WITHOUT interceptible queues..."
+	@echo "========================================"
+	./repro_hipgraph_stress
+
+# Run with interception (triggers SEGFAULT on ROCm <= 7.2)
+test-intercept: all
+	@echo "========================================"
+	@echo "Running WITH interceptible queues..."
+	@echo "========================================"
+	HSA_TOOLS_LIB=./librepro_passthrough.so ./repro_hipgraph_stress
+
+# Run both
+test: test-plain test-intercept
+
+clean:
+	rm -f librepro_passthrough.so repro_hipgraph_stress

--- a/repro/repro_README.md
+++ b/repro/repro_README.md
@@ -1,0 +1,91 @@
+# ROCm HSA Interceptible Queue SEGFAULT Reproducer
+
+## Bug Summary
+
+`hsa_amd_queue_intercept_create` queues cause SEGFAULT during rapid hipGraph
+replay with 256+ kernel dispatches. Even a **pure passthrough callback** that
+only calls `writer(in_packets, count)` without any modification triggers the
+crash. Plain queues (`hsa_queue_create`) work fine under identical workloads.
+
+## Environment
+
+- ROCm 7.2 (also observed on 6.x)
+- Any GFX9xx / CDNA / RDNA GPU
+- Linux x86_64
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `repro_passthrough_lib.cpp` | Minimal `HSA_TOOLS_LIB` that replaces `hsa_queue_create` with `hsa_amd_queue_intercept_create` + a zero-modification passthrough callback |
+| `repro_hipgraph_stress.hip` | HIP test that captures a graph with 256 kernels and replays in batches of 10-50 |
+| `Makefile` | Build and test targets |
+
+## Build
+
+```bash
+make
+```
+
+Requires `hipcc` and `g++` from a ROCm installation. Set `ROCM_PATH` if not
+at `/opt/rocm`:
+
+```bash
+make ROCM_PATH=/opt/rocm-7.2.0
+```
+
+## Reproduce
+
+### Step 1: Verify plain queues work
+
+```bash
+make test-plain
+```
+
+Expected: all batches PASS.
+
+### Step 2: Reproduce the crash with interceptible queues
+
+```bash
+make test-intercept
+```
+
+Expected: SEGFAULT during one of the replay batches (typically batch 3-5).
+
+### One-liner
+
+```bash
+make test
+```
+
+## What the tool library does
+
+The tool library (`librepro_passthrough.so`) is intentionally minimal:
+
+1. **OnLoad**: saves original API tables, replaces `hsa_queue_create` with a
+   wrapper that calls `hsa_amd_queue_intercept_create` instead.
+
+2. **Callback**: registered via `hsa_amd_queue_intercept_register`. Does
+   **only** `writer(pkts, count)` — zero packet inspection, zero signal
+   injection, zero data collection. This is the absolute minimum possible
+   interception.
+
+3. **OnUnload**: prints statistics (queues created, callbacks invoked).
+
+## Key observations
+
+- The crash occurs even with a **pure passthrough** callback (no packet
+  modification whatsoever). This rules out any tool-side bug.
+- The crash threshold is approximately 256 kernel dispatches in a single graph.
+  Graphs with fewer kernels typically survive.
+- The crash is triggered by **rapid replay without sync** — launching multiple
+  `hipGraphLaunch` calls before a single `hipStreamSynchronize`.
+- Single kernel dispatches (non-graph) work fine regardless of interceptible
+  queue usage.
+
+## Workaround
+
+Use `hsa_queue_create` (plain queues) instead of
+`hsa_amd_queue_intercept_create` when graph replay workloads are expected.
+Alternatively, detect graph replay (batch submissions with `count > 1` in the
+intercept callback) and bypass interception for those packets.

--- a/repro/repro_hipgraph_stress.hip
+++ b/repro/repro_hipgraph_stress.hip
@@ -1,0 +1,198 @@
+// repro_hipgraph_stress.hip
+//
+// Standalone hipGraph stress test that reproduces SEGFAULT with
+// interceptible queues (hsa_amd_queue_intercept_create).
+//
+// The test captures a hipGraph with NUM_KERNELS kernel dispatches,
+// then replays it in increasingly large batches without sync between
+// replays within a batch.
+//
+// With a plain queue: PASS
+// With interceptible queue (even pure passthrough callback): SEGFAULT
+//
+// Build:
+//   hipcc -o repro_hipgraph_stress repro_hipgraph_stress.hip
+//
+// Run (should PASS):
+//   ./repro_hipgraph_stress
+//
+// Run (should SEGFAULT with ROCm <= 7.2):
+//   HSA_TOOLS_LIB=./librepro_passthrough.so ./repro_hipgraph_stress
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <csignal>
+#include <setjmp.h>
+
+// Number of kernels in the captured graph.
+// 256 is the threshold where the bug typically manifests.
+#ifndef NUM_KERNELS
+#define NUM_KERNELS 256
+#endif
+
+// Batch sizes for replay stress test.
+// The bug typically manifests after ~100-200 cumulative rapid replays.
+// Escalating batch sizes to ensure we cross the threshold.
+static const int BATCH_SIZES[] = {10, 20, 50, 50, 50, 50, 50, 100, 100, 100};
+static const int NUM_BATCHES = sizeof(BATCH_SIZES) / sizeof(BATCH_SIZES[0]);
+
+#define HIP_CHECK(cmd)                                                         \
+    do {                                                                        \
+        hipError_t err = (cmd);                                                 \
+        if (err != hipSuccess) {                                                \
+            fprintf(stderr, "HIP error: %s (%d) at %s:%d\n",                   \
+                    hipGetErrorString(err), err, __FILE__, __LINE__);           \
+            exit(1);                                                            \
+        }                                                                       \
+    } while (0)
+
+// Trivial kernel — just adds two vectors
+__global__ void vec_add(const float* a, const float* b, float* c, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        c[i] = a[i] + b[i];
+    }
+}
+
+// Signal handling to catch SEGFAULT and report it cleanly
+static volatile sig_atomic_t g_got_segfault = 0;
+static sigjmp_buf g_jmp_env;
+static volatile sig_atomic_t g_jmp_set = 0;
+
+static void segfault_handler(int sig) {
+    if (g_jmp_set) {
+        g_got_segfault = 1;
+        siglongjmp(g_jmp_env, 1);
+    }
+    // If jump not set, re-raise
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+int main() {
+    // Install SIGSEGV handler
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = segfault_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGBUS, &sa, nullptr);
+
+    fprintf(stderr, "=== hipGraph intercept queue stress test ===\n");
+    fprintf(stderr, "NUM_KERNELS = %d\n", NUM_KERNELS);
+    fprintf(stderr, "If HSA_TOOLS_LIB is set, queues will be interceptible.\n\n");
+
+    // Check if HSA_TOOLS_LIB is set
+    const char* tools_lib = getenv("HSA_TOOLS_LIB");
+    if (tools_lib && tools_lib[0]) {
+        fprintf(stderr, "HSA_TOOLS_LIB = %s\n", tools_lib);
+    } else {
+        fprintf(stderr, "HSA_TOOLS_LIB not set (using plain queues)\n");
+    }
+
+    // Allocate device memory
+    const int N = 1024;
+    const size_t bytes = N * sizeof(float);
+    float *d_a, *d_b, *d_c;
+    HIP_CHECK(hipMalloc(&d_a, bytes));
+    HIP_CHECK(hipMalloc(&d_b, bytes));
+    HIP_CHECK(hipMalloc(&d_c, bytes));
+
+    // Initialize with some data
+    float* h_a = (float*)malloc(bytes);
+    float* h_b = (float*)malloc(bytes);
+    for (int i = 0; i < N; i++) {
+        h_a[i] = 1.0f;
+        h_b[i] = 2.0f;
+    }
+    HIP_CHECK(hipMemcpy(d_a, h_a, bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_b, h_b, bytes, hipMemcpyHostToDevice));
+
+    // Create stream for graph capture
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    // Capture graph with NUM_KERNELS kernel dispatches
+    fprintf(stderr, "\nCapturing hipGraph with %d kernel dispatches...\n", NUM_KERNELS);
+    HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+
+    dim3 block(256);
+    dim3 grid((N + 255) / 256);
+    for (int k = 0; k < NUM_KERNELS; k++) {
+        vec_add<<<grid, block, 0, stream>>>(d_a, d_b, d_c, N);
+    }
+
+    hipGraph_t graph;
+    HIP_CHECK(hipStreamEndCapture(stream, &graph));
+
+    // Instantiate the graph
+    hipGraphExec_t graphExec;
+    HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+    fprintf(stderr, "Graph captured and instantiated.\n\n");
+
+    int overall_pass = 1;
+
+    // Replay in batches of increasing size
+    for (int b = 0; b < NUM_BATCHES; b++) {
+        int batch = BATCH_SIZES[b];
+        fprintf(stderr, "Batch %d/%d: launching %d graph replays without sync...\n",
+                b + 1, NUM_BATCHES, batch);
+
+        g_got_segfault = 0;
+        g_jmp_set = 1;
+
+        if (sigsetjmp(g_jmp_env, 1) == 0) {
+            // Normal path: launch all replays then sync
+            for (int r = 0; r < batch; r++) {
+                HIP_CHECK(hipGraphLaunch(graphExec, stream));
+            }
+            HIP_CHECK(hipStreamSynchronize(stream));
+        }
+
+        g_jmp_set = 0;
+
+        if (g_got_segfault) {
+            fprintf(stderr, "  => FAIL: SEGFAULT during batch of %d replays!\n", batch);
+            overall_pass = 0;
+            break;
+        } else {
+            fprintf(stderr, "  => PASS (batch of %d)\n", batch);
+        }
+    }
+
+    // Verify result correctness
+    if (overall_pass) {
+        float* h_c = (float*)malloc(bytes);
+        HIP_CHECK(hipMemcpy(h_c, d_c, bytes, hipMemcpyDeviceToHost));
+        int correct = 1;
+        for (int i = 0; i < N; i++) {
+            if (h_c[i] != 3.0f) {
+                fprintf(stderr, "Verification FAILED at index %d: expected 3.0, got %f\n",
+                        i, h_c[i]);
+                correct = 0;
+                break;
+            }
+        }
+        if (correct) {
+            fprintf(stderr, "\nResult verification: PASS\n");
+        }
+        free(h_c);
+    }
+
+    // Cleanup
+    HIP_CHECK(hipGraphExecDestroy(graphExec));
+    HIP_CHECK(hipGraphDestroy(graph));
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipFree(d_a));
+    HIP_CHECK(hipFree(d_b));
+    HIP_CHECK(hipFree(d_c));
+    free(h_a);
+    free(h_b);
+
+    fprintf(stderr, "\n=== OVERALL: %s ===\n", overall_pass ? "PASS" : "FAIL");
+    return overall_pass ? 0 : 1;
+}

--- a/repro/repro_passthrough_lib.cpp
+++ b/repro/repro_passthrough_lib.cpp
@@ -1,0 +1,105 @@
+// repro_passthrough_lib.cpp
+//
+// Minimal HSA_TOOLS_LIB that replaces hsa_queue_create with
+// hsa_amd_queue_intercept_create + a pure passthrough callback.
+//
+// The callback does NOTHING except forward packets unchanged:
+//   writer(in_packets, count)
+//
+// This is the simplest possible interception — no signal injection,
+// no profiling, no data collection. Yet it causes a SEGFAULT during
+// rapid hipGraph replay with 256+ kernels.
+//
+// Build:
+//   g++ -shared -fPIC -o librepro_passthrough.so repro_passthrough_lib.cpp \
+//       -I/opt/rocm/include -L/opt/rocm/lib -lhsa-runtime64
+//
+// Usage:
+//   HSA_TOOLS_LIB=./librepro_passthrough.so ./repro_hipgraph_stress
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <atomic>
+
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#ifndef AMD_INTERNAL_BUILD
+#define AMD_INTERNAL_BUILD  // Use direct includes (not inc/ prefixed)
+#endif
+#include <hsa/hsa_api_trace.h>
+
+// Saved original API tables
+static CoreApiTable  g_orig_core;
+static AmdExtTable   g_orig_ext;
+
+static std::atomic<uint64_t> g_queues_created{0};
+static std::atomic<uint64_t> g_callbacks_invoked{0};
+
+// Pure passthrough callback — does absolutely nothing except forward packets.
+static void passthrough_callback(const void* pkts, uint64_t pkt_count,
+                                 uint64_t user_pkt_index, void* data,
+                                 hsa_amd_queue_intercept_packet_writer writer) {
+    g_callbacks_invoked.fetch_add(1, std::memory_order_relaxed);
+    // Just forward unchanged — this is the minimal possible callback.
+    writer(pkts, pkt_count);
+}
+
+// Replacement for hsa_queue_create that uses hsa_amd_queue_intercept_create.
+static hsa_status_t my_hsa_queue_create(
+    hsa_agent_t agent, uint32_t size, hsa_queue_type32_t type,
+    void (*callback)(hsa_status_t status, hsa_queue_t* source, void* data),
+    void* data, uint32_t private_segment_size, uint32_t group_segment_size,
+    hsa_queue_t** queue) {
+
+    // hsa_amd_queue_intercept_create rejects UINT32_MAX segment sizes
+    // (HIP passes UINT32_MAX to mean "use default"), so clamp to 0.
+    uint32_t safe_priv = (private_segment_size == UINT32_MAX) ? 0 : private_segment_size;
+    uint32_t safe_grp  = (group_segment_size == UINT32_MAX) ? 0 : group_segment_size;
+
+    hsa_status_t status = g_orig_ext.hsa_amd_queue_intercept_create_fn(
+        agent, size, type, callback, data,
+        safe_priv, safe_grp, queue);
+
+    if (status != HSA_STATUS_SUCCESS) {
+        fprintf(stderr, "repro: intercept_create failed (0x%x), falling back to plain queue\n",
+                (unsigned)status);
+        return g_orig_core.hsa_queue_create_fn(agent, size, type, callback, data,
+                                                private_segment_size, group_segment_size, queue);
+    }
+
+    // Register the passthrough callback via saved API table
+    g_orig_ext.hsa_amd_queue_intercept_register_fn(*queue, passthrough_callback, nullptr);
+
+    uint64_t n = g_queues_created.fetch_add(1, std::memory_order_relaxed) + 1;
+    fprintf(stderr, "repro: interceptible queue #%lu created (size=%u)\n",
+            (unsigned long)n, size);
+
+    return HSA_STATUS_SUCCESS;
+}
+
+extern "C" bool OnLoad(void* pTable,
+                        uint64_t runtimeVersion,
+                        uint64_t failedToolCount,
+                        const char* const* pFailedToolNames) {
+    fprintf(stderr, "repro: OnLoad (HSA runtime v%lu)\n", (unsigned long)runtimeVersion);
+
+    auto* table = reinterpret_cast<HsaApiTable*>(pTable);
+
+    // Save original tables
+    g_orig_core = *table->core_;
+    g_orig_ext  = *table->amd_ext_;
+
+    // Replace queue creation only — nothing else
+    table->core_->hsa_queue_create_fn = my_hsa_queue_create;
+
+    fprintf(stderr, "repro: hsa_queue_create replaced with interceptible version\n");
+    fprintf(stderr, "repro: callback does ONLY writer(pkts, count) — zero modification\n");
+    return true;
+}
+
+extern "C" void OnUnload() {
+    fprintf(stderr, "repro: OnUnload (queues created: %lu, callbacks invoked: %lu)\n",
+            (unsigned long)g_queues_created.load(),
+            (unsigned long)g_callbacks_invoked.load());
+}


### PR DESCRIPTION
## Summary

Adds the minimal reproducer for the `hsa_amd_queue_intercept_create` SEGFAULT bug (ROCR #67) that was root-caused during RTL v0.3.x development.

**Root cause:** `InterceptQueue::staging_buffer_` hardcoded at 256 AQL packets — heap overflow when hipGraph replays exceed this limit. Even a pure passthrough callback (no packet modification) triggers the crash.

**Files added:**
- `repro/repro_passthrough_lib.cpp` — minimal `HSA_TOOLS_LIB` using `hsa_amd_queue_intercept_create` with zero-modification passthrough
- `repro/repro_hipgraph_stress.hip` — HIP test: 256-kernel graph, 10–50 batch replays
- `repro/Makefile` — `make`, `make test`, `make clean`
- `repro/repro_README.md` — bug summary, environment, steps to reproduce

Fix is upstream at ROCm/rocm-systems@559d48b1 (ROCm 7.13+).

## Test plan
- [ ] `cd repro && make` builds without errors on ROCm 7.x
- [ ] `make test` reproduces SEGFAULT on ROCm < 7.13
- [ ] On ROCm 7.13+ the test passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)