### PR TITLE
feat: Record dispatch info (hwq, workgroup, grid) per kernel and gzip output

### DIFF
--- a/rocm_trace_lite/cmd_convert.py
+++ b/rocm_trace_lite/cmd_convert.py
@@ -7,6 +7,7 @@ Inlines the converter logic so it works after pip install (tools/ not in package
 import sys
 import os
 import json
+import gzip
 import sqlite3
 
 
@@ -32,7 +33,8 @@ def convert(input_rpd, output_json):
     # Collect all GPU ops
     ops = []
     for r in conn.execute("""
-        SELECT o.gpuId, o.queueId, o.start, o.end, s.string, ot.string
+        SELECT o.gpuId, o.queueId, o.start, o.end, s.string, ot.string,
+               o.completionSignal
         FROM rocpd_op o
         JOIN rocpd_string s ON o.description_id = s.id
         LEFT JOIN rocpd_string ot ON o.opType_id = ot.id
@@ -75,7 +77,7 @@ def convert(input_rpd, output_json):
 
     # GPU ops -> complete events
     op_count = 0
-    for gpu_id, queue_id, start_ns, end_ns, name, op_type in ops:
+    for gpu_id, queue_id, start_ns, end_ns, name, op_type, dispatch_info in ops:
         if gpu_id is None or gpu_id < 0:
             gpu_id = 0
 
@@ -95,6 +97,21 @@ def convert(input_rpd, output_json):
             pid = int(gpu_id)
             tid = int(queue_id) if queue_id else 0
 
+        args = {
+            "full_name": name,
+            "gpu": gpu_id,
+            "queue": queue_id,
+        }
+        # Parse dispatch_info: "hwq=0x... wg=X,Y,Z grid=X,Y,Z"
+        if dispatch_info:
+            for part in dispatch_info.split():
+                if part.startswith("hwq="):
+                    args["hwq"] = part[4:]
+                elif part.startswith("wg="):
+                    args["workgroup"] = part[3:]
+                elif part.startswith("grid="):
+                    args["grid"] = part[5:]
+
         events.append({
             "name": short_name,
             "cat": op_type or "gpu",
@@ -103,11 +120,7 @@ def convert(input_rpd, output_json):
             "tid": tid,
             "ts": (start_ns - base_ns) / 1000.0,
             "dur": (end_ns - start_ns) / 1000.0,
-            "args": {
-                "full_name": name,
-                "gpu": gpu_id,
-                "queue": queue_id,
-            }
+            "args": args,
         })
         op_count += 1
 
@@ -161,10 +174,14 @@ def convert(input_rpd, output_json):
 
     conn.close()
 
-    # Write JSON
+    # Write JSON (gzip if output ends with .gz)
     trace = {"traceEvents": events}
-    with open(output_json, 'w') as f:
-        json.dump(trace, f)
+    if output_json.endswith('.gz'):
+        with gzip.open(output_json, 'wt') as f:
+            json.dump(trace, f)
+    else:
+        with open(output_json, 'w') as f:
+            json.dump(trace, f)
 
     size_mb = os.path.getsize(output_json) / 1024 / 1024
     print(f"Written {output_json} ({size_mb:.1f} MB)")
@@ -176,7 +193,7 @@ def convert(input_rpd, output_json):
 def run_convert(args):
     """Entry point for the 'convert' subcommand."""
     input_rpd = args.input
-    output_json = args.output or input_rpd.replace(".db", ".json")
+    output_json = args.output or input_rpd.replace(".db", ".json.gz")
 
     if not os.path.exists(input_rpd):
         print(f"Error: {input_rpd} not found", file=sys.stderr)

--- a/src/hsa_intercept.cpp
+++ b/src/hsa_intercept.cpp
@@ -54,10 +54,11 @@ static std::unordered_map<uint64_t, std::string> g_symbols;
 static std::vector<hsa_agent_t> g_gpu_agents;
 static std::mutex g_agent_mutex;
 
-// Queue info: maps queue handle -> device index
+// Queue info: maps queue handle -> device index + queue base address
 struct QueueInfo {
     int device_id;
-    uint64_t queue_handle;  // for stable queue identification
+    uint64_t queue_handle;   // hsa_queue_t pointer (for stable identification)
+    uint64_t hw_queue_addr;  // hsa_queue_t::base_address (AQL ring buffer)
 };
 static std::mutex g_queue_mutex;
 static std::unordered_map<uint64_t, QueueInfo> g_queue_map;  // keyed by hsa_queue_t pointer
@@ -180,6 +181,9 @@ struct DispatchData {
     uint64_t queue_id;
     hsa_signal_t profiling_signal;  // injected signal (we own this)
     hsa_signal_t original_signal;   // original from packet (may be null)
+    uint64_t hw_queue_addr;         // HW queue base_address
+    uint16_t wg_x, wg_y, wg_z;     // workgroup size from AQL packet
+    uint32_t grid_x, grid_y, grid_z; // grid size from AQL packet
 };
 
 static std::mutex g_work_mutex;
@@ -250,8 +254,15 @@ static void completion_worker() {
             g_drop_ts_invalid.fetch_add(1, std::memory_order_relaxed);
         } else {
             std::string name = lookup_kernel_name(dd->kernel_object);
+            char dispatch_info[128];
+            snprintf(dispatch_info, sizeof(dispatch_info),
+                     "hwq=0x%" PRIx64 " wg=%u,%u,%u grid=%u,%u,%u",
+                     dd->hw_queue_addr,
+                     (unsigned)dd->wg_x, (unsigned)dd->wg_y, (unsigned)dd->wg_z,
+                     dd->grid_x, dd->grid_y, dd->grid_z);
             get_trace_db().record_kernel(name.c_str(), dd->device_id, dd->queue_id,
-                                          time.start, time.end, dd->correlation_id);
+                                          time.start, time.end, dd->correlation_id,
+                                          dispatch_info);
             g_recorded_ok.fetch_add(1, std::memory_order_relaxed);
         }
 
@@ -501,6 +512,13 @@ static void queue_intercept_cb(const void* in_packets, uint64_t count,
         dd->queue_id = qi->queue_handle;
         dd->profiling_signal = prof_sig;
         dd->original_signal = orig_sig;
+        dd->hw_queue_addr = qi->hw_queue_addr;
+        dd->wg_x = pkt->workgroup_size_x;
+        dd->wg_y = pkt->workgroup_size_y;
+        dd->wg_z = pkt->workgroup_size_z;
+        dd->grid_x = pkt->grid_size_x;
+        dd->grid_y = pkt->grid_size_y;
+        dd->grid_z = pkt->grid_size_z;
 
         dd_list[dd_count++] = dd;
         g_injected.fetch_add(1, std::memory_order_relaxed);
@@ -565,10 +583,11 @@ static hsa_status_t my_hsa_queue_create(
         fprintf(stderr, "rtl: warning: failed to enable profiling on queue (status=%d)\n", (int)prof_status);
     }
 
-    // Build queue info
+    // Build queue info — read base_address from the queue struct.
     auto* qi = new QueueInfo;
     qi->device_id = 0;
     qi->queue_handle = (uint64_t)(*queue);
+    qi->hw_queue_addr = (*queue) ? (uint64_t)(*queue)->base_address : 0;
 
     {
         std::lock_guard<std::mutex> lock(g_agent_mutex);

--- a/src/trace_db.cpp
+++ b/src/trace_db.cpp
@@ -215,8 +215,8 @@ bool TraceDB::open(const std::string& filename) {
                  &stmt_kernel_, "api_insert"))
         return false;
 
-    if (!prepare("INSERT INTO rocpd_op(gpuId,queueId,sequenceId,start,end,description_id,opType_id) "
-                 "VALUES(?1,?2,0,?3,?4,"
+    if (!prepare("INSERT INTO rocpd_op(gpuId,queueId,sequenceId,completionSignal,start,end,description_id,opType_id) "
+                 "VALUES(?1,?2,0,?7,?3,?4,"
                  "(SELECT id FROM rocpd_string WHERE string=?5),"
                  "(SELECT id FROM rocpd_string WHERE string=?6))",
                  &stmt_copy_, "op_insert"))
@@ -307,7 +307,8 @@ void TraceDB::record_hip_api(const char* name, const char* args,
 
 void TraceDB::record_kernel(const char* name, int device_id, uint64_t queue_id,
                              uint64_t start_ns, uint64_t end_ns,
-                             uint64_t correlation_id) {
+                             uint64_t correlation_id,
+                             const char* dispatch_info) {
     std::lock_guard<std::mutex> lock(g_db_mutex);
     if (!db_) return;
 
@@ -321,6 +322,11 @@ void TraceDB::record_kernel(const char* name, int device_id, uint64_t queue_id,
     sqlite3_bind_int64(stmt_copy_, 4, end_ns);
     sqlite3_bind_text(stmt_copy_, 5, name, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt_copy_, 6, "KernelExecution", -1, SQLITE_STATIC);
+    if (dispatch_info && dispatch_info[0]) {
+        sqlite3_bind_text(stmt_copy_, 7, dispatch_info, -1, SQLITE_TRANSIENT);
+    } else {
+        sqlite3_bind_null(stmt_copy_, 7);
+    }
     if (step_ok(stmt_copy_)) { ++records_written_; } else { ++records_dropped_; }
 
     if (++batch_count_ >= 1000) {
@@ -347,6 +353,7 @@ void TraceDB::record_copy(int src_device, int dst_device, size_t bytes,
     sqlite3_bind_int64(stmt_copy_, 4, end_ns);
     sqlite3_bind_text(stmt_copy_, 5, desc, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt_copy_, 6, "CopyDeviceToDevice", -1, SQLITE_STATIC);
+    sqlite3_bind_null(stmt_copy_, 7);
     if (step_ok(stmt_copy_)) { ++records_written_; } else { ++records_dropped_; }
 
     if (++batch_count_ >= 1000) {
@@ -370,6 +377,7 @@ void TraceDB::record_roctx(const char* message, uint64_t start_ns, uint64_t dura
     sqlite3_bind_int64(stmt_copy_, 4, start_ns + duration_ns);
     sqlite3_bind_text(stmt_copy_, 5, message, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt_copy_, 6, "UserMarker", -1, SQLITE_STATIC);
+    sqlite3_bind_null(stmt_copy_, 7);
     if (step_ok(stmt_copy_)) { ++records_written_; } else { ++records_dropped_; }
 
     if (++batch_count_ >= 1000) {

--- a/src/trace_db.h
+++ b/src/trace_db.h
@@ -33,9 +33,11 @@ public:
                         uint64_t correlation_id, int pid, int tid);
 
     // Record a GPU kernel dispatch (device-side)
+    // dispatch_info: optional "hwq=0x... wg=X,Y,Z grid=X,Y,Z" stored in completionSignal
     void record_kernel(const char* name, int device_id, uint64_t queue_id,
                        uint64_t start_ns, uint64_t end_ns,
-                       uint64_t correlation_id);
+                       uint64_t correlation_id,
+                       const char* dispatch_info = nullptr);
 
     // Record a GPU memory copy (device-side)
     void record_copy(int src_device, int dst_device, size_t bytes,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,7 +159,7 @@ class TestConvertCommand:
         populate_synthetic_trace(rpd, num_kernels=5)
         rc, _, _ = _run_cli("convert", rpd)
         assert rc == 0
-        json_path = str(tmp_path / "test.json")
+        json_path = str(tmp_path / "test.json.gz")
         assert os.path.exists(json_path)
 
     def test_convert_missing_file(self):

--- a/tests/test_rpd2trace.py
+++ b/tests/test_rpd2trace.py
@@ -199,14 +199,14 @@ class TestConverterOutput:
         assert os.path.getsize(out_json) > 0
 
     def test_default_output_name(self, tmp_path):
-        """Default output should be input.db -> input.json."""
+        """Default output should be input.db -> input.json.gz."""
         rpd_path = str(tmp_path / "mytrace.db")
         populate_synthetic_trace(rpd_path, num_kernels=5)
         subprocess.run(
             [sys.executable, RPD2TRACE, rpd_path],
             check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         )
-        json_path = str(tmp_path / "mytrace.json")
+        json_path = str(tmp_path / "mytrace.json.gz")
         assert os.path.exists(json_path)
 
     def test_metadata_events_present(self, tmp_rpd, tmp_path):

--- a/tools/rpd2trace.py
+++ b/tools/rpd2trace.py
@@ -12,6 +12,7 @@ Usage:
 
 import sys
 import json
+import gzip
 import sqlite3
 import os
 
@@ -36,7 +37,8 @@ def convert(input_rpd, output_json):
     # Collect all GPU ops
     ops = []
     for r in conn.execute("""
-        SELECT o.gpuId, o.queueId, o.start, o.end, s.string, ot.string
+        SELECT o.gpuId, o.queueId, o.start, o.end, s.string, ot.string,
+               o.completionSignal
         FROM rocpd_op o
         JOIN rocpd_string s ON o.description_id = s.id
         LEFT JOIN rocpd_string ot ON o.opType_id = ot.id
@@ -83,7 +85,7 @@ def convert(input_rpd, output_json):
 
     # GPU ops -> complete events
     op_count = 0
-    for gpu_id, queue_id, start_ns, end_ns, name, op_type in ops:
+    for gpu_id, queue_id, start_ns, end_ns, name, op_type, dispatch_info in ops:
         if gpu_id is None or gpu_id < 0:
             gpu_id = 0
 
@@ -103,6 +105,21 @@ def convert(input_rpd, output_json):
             pid = int(gpu_id)
             tid = int(queue_id) if queue_id else 0
 
+        args = {
+            "full_name": name,
+            "gpu": gpu_id,
+            "queue": queue_id,
+        }
+        # Parse dispatch_info: "hwq=0x... wg=X,Y,Z grid=X,Y,Z"
+        if dispatch_info:
+            for part in dispatch_info.split():
+                if part.startswith("hwq="):
+                    args["hwq"] = part[4:]
+                elif part.startswith("wg="):
+                    args["workgroup"] = part[3:]
+                elif part.startswith("grid="):
+                    args["grid"] = part[5:]
+
         events.append({
             "name": short_name,
             "cat": op_type or "gpu",
@@ -111,11 +128,7 @@ def convert(input_rpd, output_json):
             "tid": tid,
             "ts": (start_ns - base_ns) / 1000.0,
             "dur": (end_ns - start_ns) / 1000.0,
-            "args": {
-                "full_name": name,
-                "gpu": gpu_id,
-                "queue": queue_id,
-            }
+            "args": args,
         })
         op_count += 1
 
@@ -170,10 +183,14 @@ def convert(input_rpd, output_json):
 
     conn.close()
 
-    # Write JSON
+    # Write JSON (gzip if output ends with .gz)
     trace = {"traceEvents": events}
-    with open(output_json, 'w') as f:
-        json.dump(trace, f)
+    if output_json.endswith('.gz'):
+        with gzip.open(output_json, 'wt') as f:
+            json.dump(trace, f)
+    else:
+        with open(output_json, 'w') as f:
+            json.dump(trace, f)
 
     size_mb = os.path.getsize(output_json) / 1024 / 1024
     print(f"Written {output_json} ({size_mb:.1f} MB)")
@@ -187,5 +204,5 @@ if __name__ == "__main__":
         sys.exit(1)
 
     input_rpd = sys.argv[1]
-    output_json = sys.argv[2] if len(sys.argv) > 2 else input_rpd.replace('.db', '.json')
+    output_json = sys.argv[2] if len(sys.argv) > 2 else input_rpd.replace('.db', '.json.gz')
     convert(input_rpd, output_json)


### PR DESCRIPTION
## Summary
- Record per-dispatch HW queue base_address, workgroup_size, and grid_size from AQL packets into `rocpd_op.completionSignal`
- Perfetto converter parses dispatch_info into event args (hwq, workgroup, grid) visible in Details panel
- Default Perfetto output changed from `.json` to `.json.gz` (~40x smaller)
- Synced `tools/rpd2trace.py` with `cmd_convert.py`

## Details

Each kernel dispatch now records `"hwq=0x... wg=X,Y,Z grid=X,Y,Z"` in the `completionSignal` column. The hwq address is read from `hsa_queue_t::base_address` and matches `AMD_LOG_LEVEL=3` output from `rocdevice.cpp`.

## Test plan
- [x] `make -j` compiles cleanly in rocm/atom-dev container
- [x] 216 CPU tests pass (2 test updates for .json.gz default)
- [x] GPU smoke test: `gpu_workload gemm` shows correct hwq/wg/grid
- [x] Verified hwq matches AMD_LOG_LEVEL=3 on MI355X with GPT-OSS-120B TP=8
- [x] Verified with DeepSeek-R1-671B TP=8 (277K ops/rank, all with dispatch_info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)