### PR TITLE
fix(build): prefer repo-root librtl.so + add benchmark skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,7 +13,6 @@
 ## Known Issues
 - RTL lite mode: ~0% overhead on MoE models with CUDAGraph, ~5-6% on enforce-eager
 - RTL hip mode: GPU_CLR_PROFILE_OUTPUT + CUDAGraph replay = crash (issue #79)
-- roctracer: ROCP_OUTPUT_DIR must be set or stdout floods cause OOM
 
 ## Code Style
 - All GitHub issues/PRs/commits in English

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,20 @@
+# rocm-trace-lite — Claude Code Instructions
+
+## Benchmark Testing
+- Use `/gpu-bench` skill for ALL remote GPU benchmark work — no exceptions
+- Always verify installed librtl.so matches source after wheel install (md5sum)
+- Always capture RTL diagnostic counters (intercept/inject/skip) after profiled runs
+
+## Build
+- `make` outputs librtl.so to repo root; setup.py packages from there
+- Always `make clean && make` before `python3 setup.py bdist_wheel`
+- Run `python3 -m pytest tests/ -v --tb=short` before any commit
+
+## Known Issues
+- RTL lite mode: ~0% overhead on MoE models with CUDAGraph, ~5-6% on enforce-eager
+- RTL hip mode: GPU_CLR_PROFILE_OUTPUT + CUDAGraph replay = crash (issue #79)
+- roctracer: ROCP_OUTPUT_DIR must be set or stdout floods cause OOM
+
+## Code Style
+- All GitHub issues/PRs/commits in English
+- Run `ruff check` before push

--- a/.claude/commands/gpu-bench.md
+++ b/.claude/commands/gpu-bench.md
@@ -82,8 +82,6 @@ HSA_TOOLS_LIB="$LIBRTL" RTL_OUTPUT="$OUTDIR/trace_%p.db" RTL_MODE=lite
 # hip mode (requires CLR profiler-enabled libamdhip64.so)
 HSA_TOOLS_LIB="$LIBRTL" RTL_MODE=hip RTL_OUTPUT="$OUTDIR/trace_%p.db" GPU_CLR_PROFILE_OUTPUT=/dev/null
 
-# roctracer (MUST set ROCP_OUTPUT_DIR or stdout OOM)
-HSA_TOOLS_LIB="/opt/rocm/lib/roctracer/libroctracer_tool.so" ROCTRACER_DOMAIN="hip" ROCP_OUTPUT_DIR="/tmp/roctracer_output"
 ```
 
 ## Process Cleanup (CRITICAL)
@@ -112,5 +110,4 @@ done
 
 - RTL lite: ~0% overhead on MoE with CUDAGraph, ~5-6% on enforce-eager
 - RTL hip mode: GPU_CLR_PROFILE_OUTPUT + CUDAGraph = crash (CLR dispatch wrapper incompatibility)
-- roctracer on serving: unusable without ROCP_OUTPUT_DIR (stdout OOM)
 - setup.py packaging: always `make` before `bdist_wheel` — repo-root librtl.so takes priority

--- a/.claude/commands/gpu-bench.md
+++ b/.claude/commands/gpu-bench.md
@@ -1,0 +1,116 @@
+Run E2E serving benchmarks on remote GPU nodes. Handles pre-flight, server launch, benchmark execution, monitoring, and post-flight cleanup.
+
+MANDATORY: Use this skill for ANY work involving remote GPU servers. No exception.
+
+## Arguments
+$ARGUMENTS — model name / benchmark description / specific configs
+
+## Pre-flight Checklist (MANDATORY)
+
+### 1. Verify GPU Cleanliness
+Check KFD processes (actual GPU users), not just container status:
+```bash
+ssh $NODE 'for d in /sys/class/kfd/kfd/proc/*/; do pid=$(basename $d); echo "PID=$pid CMD=$(cat /proc/$pid/cmdline 2>/dev/null | tr "\0" " " | head -c 200)"; done'
+```
+
+### 2. Docker Image — Pull Fresh
+NEVER trust existing images. Always pull before benchmark:
+```bash
+ssh $NODE 'docker pull $IMAGE && docker inspect $IMAGE --format "{{.Created}}"'
+```
+
+### 3. Check ATOM Server Args
+Different ATOM versions support different args. ALWAYS check before scripting:
+```bash
+ssh $NODE 'docker run --rm $IMAGE python3 -m atom.entrypoints.openai_server --help 2>&1 | head -30'
+```
+
+### 4. Verify Benchmark Module Path
+```bash
+ssh $NODE 'docker run --rm $IMAGE python3 -m atom.benchmarks.benchmark_serving --help 2>&1 | head -5'
+```
+
+### 5. Pre-launch Port Check
+```bash
+if ss -tlnp | grep -q ":${PORT} "; then echo "ERROR: port in use"; exit 1; fi
+```
+
+## RTL Wheel Verification (MANDATORY after install)
+
+Stale .so in wheel caused phantom -32.7% overhead. Always verify:
+```bash
+INSTALLED=$(python3 -c "from rocm_trace_lite import get_lib_path; print(get_lib_path())")
+md5sum $INSTALLED
+nm -D $INSTALLED | grep -c hip_profiler  # 0=main, 2=hip branch
+ls -la $INSTALLED  # check timestamp
+```
+
+## RTL Diagnostic Validation (MANDATORY after profiled run)
+
+Capture intercept/inject/skip stats. Catches broken lite mode immediately:
+```bash
+# Expected for lite mode with CUDAGraph:
+#   drop (not kernel): M  ← should be >50% (lite skip)
+#   drop (batch skip): K  ← CUDAGraph replay skips
+# RED FLAG: if inject ≈ intercept (near 100%), lite is NOT skipping
+```
+
+## Warmup Before Benchmark (MANDATORY)
+
+Send warmup prompts BEFORE timed run. torch.compile/JIT compiles on first invocation:
+```bash
+python3 -m atom.benchmarks.benchmark_serving \
+    --backend openai --endpoint /v1/completions --model "$MODEL" \
+    --dataset-name random --random-input-len $ISL --random-output-len $OSL \
+    --num-prompts 5 --max-concurrency $CONC --ignore-eos > /dev/null 2>&1
+```
+
+## Server Launch Pattern
+
+Logs MUST go to docker stdout (use tee, NOT redirect to file only):
+```bash
+python3 -m atom.entrypoints.openai_server \
+    --model "$MODEL" -tp $TP --gpu-memory-utilization 0.9 --port $PORT \
+    2>&1 | tee "$OUTDIR/${label}_server.log" &
+```
+
+## RTL Profiler Env Vars (set on SERVER process)
+```bash
+# lite mode (zero overhead with CUDAGraph)
+HSA_TOOLS_LIB="$LIBRTL" RTL_OUTPUT="$OUTDIR/trace_%p.db" RTL_MODE=lite
+
+# hip mode (requires CLR profiler-enabled libamdhip64.so)
+HSA_TOOLS_LIB="$LIBRTL" RTL_MODE=hip RTL_OUTPUT="$OUTDIR/trace_%p.db" GPU_CLR_PROFILE_OUTPUT=/dev/null
+
+# roctracer (MUST set ROCP_OUTPUT_DIR or stdout OOM)
+HSA_TOOLS_LIB="/opt/rocm/lib/roctracer/libroctracer_tool.so" ROCTRACER_DOMAIN="hip" ROCP_OUTPUT_DIR="/tmp/roctracer_output"
+```
+
+## Process Cleanup (CRITICAL)
+
+kill $PID only kills main process. ATOM spawns 8+ workers:
+```bash
+pkill -9 -f "atom.entrypoints.openai_server"
+pkill -9 -f "multiprocessing.spawn"
+pkill -9 -f "compile_worker"
+sleep 10
+# Verify GPU release
+for i in $(seq 1 60); do
+    pids=$(cat /sys/class/kfd/kfd/proc/*/pasid 2>/dev/null | wc -l)
+    [ "$pids" -eq 0 ] && break; sleep 1
+done
+```
+
+## Trust Boundaries (HARD RULES)
+
+1. NEVER trust binaries on remote systems — always build/pull fresh
+2. NEVER trust Docker images already on nodes — always pull
+3. NEVER reuse custom-tagged images from previous sessions
+4. ALWAYS verify after pull — check creation date, key binaries, versions
+
+## Known Issues
+
+- RTL lite: ~0% overhead on MoE with CUDAGraph, ~5-6% on enforce-eager
+- RTL hip mode: GPU_CLR_PROFILE_OUTPUT + CUDAGraph = crash (CLR dispatch wrapper incompatibility)
+- roctracer on serving: unusable without ROCP_OUTPUT_DIR (stdout OOM)
+- setup.py packaging: always `make` before `bdist_wheel` — repo-root librtl.so takes priority

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ This setup.py attempts compilation during `pip install` from source.
 If ROCm is not available, the install succeeds but tracing is disabled.
 """
 import os
+import time
 import shutil
 import sys
 
@@ -48,8 +49,15 @@ class BuildWithLibrtl(build_py):
         # to avoid packaging a stale .so
         for src_so in ["librtl.so", os.path.join("rocm_trace_lite", "lib", "librtl.so")]:
             if os.path.isfile(src_so):
+                age_s = time.time() - os.path.getmtime(src_so)
+                if age_s > 3600:
+                    print("rocm-trace-lite: WARNING: packaging %s (%.0f min old) "
+                          "— run `make` to rebuild" % (src_so, age_s / 60),
+                          file=sys.stderr)
                 os.makedirs(lib_dest, exist_ok=True)
                 shutil.copy2(src_so, so_path)
+                print("rocm-trace-lite: packaged %s (%.1f KB)" %
+                      (src_so, os.path.getsize(so_path) / 1024))
                 return
 
         # Attempt JIT compilation

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,13 @@ class BuildWithLibrtl(build_py):
             return
 
         # Check if user already ran `make` in source tree
-        src_so = os.path.join("rocm_trace_lite", "lib", "librtl.so")
-        if os.path.isfile(src_so):
-            os.makedirs(lib_dest, exist_ok=True)
-            shutil.copy2(src_so, so_path)
-            return
+        # Prefer repo-root librtl.so (make output) over package-dir copy
+        # to avoid packaging a stale .so
+        for src_so in ["librtl.so", os.path.join("rocm_trace_lite", "lib", "librtl.so")]:
+            if os.path.isfile(src_so):
+                os.makedirs(lib_dest, exist_ok=True)
+                shutil.copy2(src_so, so_path)
+                return
 
         # Attempt JIT compilation
         try:


### PR DESCRIPTION
## Summary
- **setup.py fix**: Wheel packaging now prefers repo-root `librtl.so` (make output) over `rocm_trace_lite/lib/librtl.so` (potentially stale copy). This caused a phantom -32.7% overhead regression during benchmarking — the wheel silently packaged an old .so.
- **`.claude/` skills**: Adds project-level Claude Code instructions and `/gpu-bench` benchmark skill with pre-flight checklist, RTL verification steps, and known issues.

## Changes
- `setup.py`: Check `./librtl.so` before `rocm_trace_lite/lib/librtl.so` in `BuildWithLibrtl.run()`
- `.claude/CLAUDE.md`: Project instructions (build, test, known issues)
- `.claude/commands/gpu-bench.md`: Comprehensive benchmark skill

## Test plan
- [ ] `make clean && make && python3 setup.py bdist_wheel` produces wheel with fresh .so
- [ ] `md5sum` of .so inside wheel matches repo-root .so
- [ ] Existing `pytest tests/` passes (no test changes)