### PR TITLE
docs: Fix documentation inconsistencies with codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Output files:
 2. **Queue intercept** — We replace `hsa_queue_create` to create interceptible queues via `hsa_amd_queue_intercept_create`, then register a callback on every AQL packet
 3. **Kernel profiling** — For each kernel dispatch packet, we insert a profiling signal, wait for completion, then read GPU timestamps via `hsa_amd_profiling_get_dispatch_time`
 4. **Symbol resolution** — We intercept `hsa_executable_freeze` to enumerate kernel symbols from code objects
-5. **roctx shim** — Provides `roctxRangePushA`/`roctxRangePop`/`roctxMarkA` symbols so applications using roctx markers get captured without linking libroctx64
+5. **roctx shim** — Provides `roctxRangePushA`/`roctxRangePop`/`roctxMarkA`/`roctxRangeStartA`/`roctxRangeStop` symbols so applications using roctx markers get captured without linking libroctx64
 
 ## Output format
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,18 @@
 # Changelog
 
+## v0.3.4
+
+- **Dispatch info**: Record hardware queue ID, workgroup size, and grid dimensions per kernel in the `completionSignal` column of `rocpd_op`
+- **Gzip Perfetto output**: `rtl trace` now produces compressed `.json.gz` files for Perfetto timeline visualization
+- **Build fix**: prefer repo-root `librtl.so` over system-installed version during development
+- Add ROCR interceptible queue SEGFAULT reproducer (`repro/`)
+- Sync `__version__` with `pyproject.toml`
+
 ## v0.3.3
 
 - **Fix roctx support**: `rtl trace` now sets `LD_PRELOAD` automatically so roctx markers work without manual setup
 - Add tutorial: profiling prefill vs decode with roctx markers
+- Add MI355X benchmark results and hot trace viewer as sample pages
 
 ## v0.3.2
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-rocm-trace-lite provides the `rtl` command-line tool. (`rpd-lite` also works as an alias.)
+rocm-trace-lite provides the `rtl` command-line tool. (`rtl-legacy` also works as an alias.)
 
 ## rtl trace
 
@@ -95,7 +95,7 @@ rtl info trace.db
 ```text
 Trace: trace.db
   Size: 1.2 MB
-  Tables: rocpd_api, rocpd_metadata, rocpd_op, rocpd_string
+  Tables: rocpd_api, rocpd_api_ops, rocpd_copyapi, rocpd_kernelapi, rocpd_metadata, rocpd_monitor, rocpd_op, rocpd_string
   rocpd_op: 728 rows
   rocpd_string: 45 rows
   Duration: 13.247s

--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -78,8 +78,10 @@ hsa_executable_iterate_symbols(executable, symbol_iterate_cb, nullptr);
 
 ### 6. roctx shim
 
-The library exports `roctxRangePushA`, `roctxRangePop`, and `roctxMarkA` symbols,
-allowing applications that use roctx markers to work without linking `libroctx64`.
+The library exports `roctxRangePushA`, `roctxRangePop`, `roctxMarkA`, `roctxRangeStartA`,
+and `roctxRangeStop` symbols, allowing applications that use roctx markers to work
+without linking `libroctx64`. Both nested (push/pop) and non-nested (start/stop) ranges
+are supported.
 
 ## Signal pool design
 

--- a/docs/multi_gpu.md
+++ b/docs/multi_gpu.md
@@ -54,7 +54,7 @@ This reports per-file kernel counts, GPU IDs, and flags asymmetry between proces
 Each process prints diagnostic counters at shutdown:
 
 ```text
-=== rpd_lite diagnostic (PID 336455) ===
+=== rtl diagnostic (PID 336455) ===
   intercept calls:     3380
   signals injected:    2630
   drop (shutdown):     0

--- a/docs/output_format.md
+++ b/docs/output_format.md
@@ -13,6 +13,7 @@ GPU operations (kernel dispatches, roctx markers).
 | `gpuId` | INTEGER | GPU device index (0-based). -1 for host-side markers |
 | `queueId` | INTEGER | HSA queue handle |
 | `sequenceId` | INTEGER | Sequence number |
+| `completionSignal` | TEXT | Dispatch info string (hwq, workgroup, grid dimensions). NULL for markers. |
 | `start` | INTEGER | Start timestamp (nanoseconds) |
 | `end` | INTEGER | End timestamp (nanoseconds) |
 | `description_id` | INTEGER | FK to `rocpd_string` (kernel name) |
@@ -38,7 +39,66 @@ Trace-level metadata.
 
 ### rocpd_api
 
-HIP API calls (empty in rocm-trace-lite; reserved for RPD compatibility).
+HIP API calls (reserved for RPD compatibility; populated in future HIP profiling mode).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `pid` | INTEGER | Process ID |
+| `tid` | INTEGER | Thread ID |
+| `start` | INTEGER | Start timestamp (nanoseconds) |
+| `end` | INTEGER | End timestamp (nanoseconds) |
+| `apiName_id` | INTEGER | FK to `rocpd_string` (API function name) |
+| `args_id` | INTEGER | FK to `rocpd_string` (API arguments) |
+
+### rocpd_api_ops
+
+Association table linking API calls to GPU operations.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `api_id` | INTEGER | FK to `rocpd_api` |
+| `op_id` | INTEGER | FK to `rocpd_op` |
+
+### rocpd_kernelapi
+
+Kernel launch details (grid/workgroup dimensions).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `api_id` | INTEGER | FK to `rocpd_api` (PK) |
+| `stream` | TEXT | HIP stream handle |
+| `gridX/Y/Z` | INTEGER | Grid dimensions |
+| `workgroupX/Y/Z` | INTEGER | Workgroup dimensions |
+| `groupSegmentSize` | INTEGER | Group segment size (bytes) |
+| `privateSegmentSize` | INTEGER | Private segment size (bytes) |
+| `kernelName_id` | INTEGER | FK to `rocpd_string` |
+
+### rocpd_copyapi
+
+Memory copy details.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `api_id` | INTEGER | FK to `rocpd_api` (PK) |
+| `stream` | TEXT | HIP stream handle |
+| `size` | INTEGER | Copy size (bytes) |
+| `dst` | TEXT | Destination address |
+| `src` | TEXT | Source address |
+| `kind` | INTEGER | Copy kind (H2D, D2H, D2D, etc.) |
+| `sync` | INTEGER | Synchronous flag |
+
+### rocpd_monitor
+
+Monitoring data (reserved for future use).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `deviceType` | TEXT | Device type |
+| `deviceId` | INTEGER | Device ID |
+| `monitorType` | TEXT | Monitor metric type |
+| `start` | INTEGER | Start timestamp |
+| `end` | INTEGER | End timestamp |
+| `value` | TEXT | Metric value |
 
 ## Built-in views
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,10 +83,18 @@ Applications that use roctx markers are captured automatically:
 import ctypes
 lib = ctypes.CDLL("librtl.so")
 
+# Nested ranges (push/pop)
 lib.roctxRangePushA(b"forward_pass")
 # ... GPU work ...
 lib.roctxRangePop()
 
+# Non-nested ranges (start/stop)
+lib.roctxRangeStartA.restype = ctypes.c_uint64
+rid = lib.roctxRangeStartA(b"data_loading")
+# ... work ...
+lib.roctxRangeStop(rid)
+
+# Instant markers
 lib.roctxMarkA(b"checkpoint")
 ```
 
@@ -98,20 +106,20 @@ CUDAGraph replay submits batch AQL packets that are incompatible with signal inj
 rocm-trace-lite automatically skips batch submissions (`count > 1`), so graph-replayed
 kernels are not profiled but the application runs correctly.
 
-If you still see crashes (e.g., graph capture baking stale signal handles), use:
+If you still see crashes (e.g., graph capture baking stale signal handles), use
+**lite** mode which skips packets that already have a completion signal:
 
 ```bash
-RTL_NO_INJECT=1 rtl trace -o trace.db python3 my_cudagraph_model.py
+rtl trace --mode lite -o trace.db python3 my_cudagraph_model.py
 ```
 
-This disables signal injection entirely. No kernel timestamps are collected,
-but HIP API tracing still works.
+Lite mode provides near-zero overhead and is the safest option for CUDAGraph workloads.
 
 ## Environment variables
 
 | Variable | Values | Description |
 |----------|--------|-------------|
-| `RTL_OUTPUT` | path | Output trace file (supports `%p` for PID). Alternative to `-o` flag. |
+| `RTL_OUTPUT` | path | Output trace file (supports `%p` for PID). Alternative to `-o` flag. `RPD_LITE_OUTPUT` also accepted for backward compatibility. |
 | `RTL_MODE` | `default`, `lite`, `full` | Profiling mode (see below) |
 | `RTL_DEBUG` | `1`, `2` | Packet-level diagnostic logging (1=summary, 2=per-packet) |
 

--- a/tools/rtl.sh
+++ b/tools/rtl.sh
@@ -37,7 +37,7 @@ if [ $# -eq 0 ]; then
 fi
 
 rm -f "$OUTPUT"
-echo "rpd_lite: tracing to $OUTPUT"
+echo "rtl: tracing to $OUTPUT"
 
 RTL_OUTPUT="$OUTPUT" \
 HSA_TOOLS_LIB="$LIB" \


### PR DESCRIPTION
## Summary
- Remove fictional `RTL_NO_INJECT` env var from quickstart (was never implemented in C++ code)
- Document all 8 database tables in output_format.md (was only showing 4 of 8)
- Add `completionSignal` column documentation (dispatch info: hwq, workgroup, grid from PR #87)
- Add v0.3.4 changelog entry (dispatch info, gzip Perfetto output, build fix)
- Fix CLI alias: `rpd-lite` → `rtl-legacy` (matches pyproject.toml)
- Fix diagnostic output prefix in multi_gpu.md: `rpd_lite` → `rtl` (matches hsa_intercept.cpp)
- Document `roctxRangeStartA`/`roctxRangeStop` in quickstart and how_it_works
- Note `RPD_LITE_OUTPUT` backward compatibility in env var table
- Update `rtl info` example output to show all 8 tables
- Fix `tools/rtl.sh` to use `rtl:` prefix instead of `rpd_lite:`

## Test plan
- [x] `pytest tests/test_cli.py tests/test_source_guard.py` — 36/36 pass
- [x] `ruff check` clean on all changed files
- [ ] CI: lint, build, GPU tests