### PR TITLE
Rename profiling mode 'default' to 'standard'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,22 +60,22 @@ Requirements:
 ## Quick start
 
 ```bash
-rtl trace python3 my_model.py                    # default mode
-rtl trace --mode lite python3 my_model.py        # lite mode (~0% overhead)
-rtl trace --mode full python3 my_model.py        # full mode (requires ROCm 7.13+)
+rtl trace python3 my_model.py                        # lite mode (default)
+rtl trace --mode standard python3 my_model.py        # standard mode (~2-4% overhead)
+rtl trace --mode full python3 my_model.py             # full mode (requires ROCm 7.13+)
 ```
 
 ### Profiling modes
 
 | Mode | GPU timing | Graph replay | Overhead | Use case |
 |------|-----------|-------------|----------|----------|
-| **lite** (default) | Yes (partial) | Skipped | ~0% | Production / always-on |
-| default | Yes | Skipped | ~2-4% | General profiling |
+| **lite** | Yes (partial) | Skipped | ~0% | Production / always-on **(default)** |
+| **standard** | Yes | Skipped | ~2-4% | General profiling |
 | **full** | Yes (all) | Profiled | ~2-5% | Deep analysis (requires ROCm 7.13+ with [ROCR fix](https://github.com/ROCm/rocm-systems/commit/559d48b1)) |
 
 Set via CLI (`--mode`) or env var (`RTL_MODE=lite`).
 
-**lite** (default) skips packets that already have a completion signal (e.g., NCCL kernels, barriers), resulting in near-zero overhead and safety on ROCm <= 7.2. **default** mode profiles all count==1 dispatches including those with signals. **full** profiles everything including CUDAGraph replay batches, but requires ROCm 7.13+ to avoid a [known ROCR heap overflow](https://github.com/sunway513/rocm-trace-lite/issues/67).
+**lite** skips packets that already have a completion signal (e.g., NCCL kernels, barriers), resulting in near-zero overhead and safety on ROCm <= 7.2. This is the default when `--mode` is not specified. **standard** mode profiles all count==1 dispatches including those with signals. **full** profiles everything including CUDAGraph replay batches, but requires ROCm 7.13+ to avoid a [known ROCR heap overflow](https://github.com/sunway513/rocm-trace-lite/issues/67).
 
 Sample output:
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -107,6 +107,6 @@ Trace: trace.db
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `RTL_OUTPUT` | file path | Output trace file (supports `%p` for PID). Alternative to `-o` flag. |
-| `RTL_MODE` | `default`, `lite`, `full` | Profiling mode. `default`: signal injection, skip graph replay. `lite`: also skip has-signal packets (~0% overhead). `full`: profile everything including graph replay (requires ROCm 7.13+). |
+| `RTL_MODE` | `lite`, `standard`, `full` | Profiling mode. `lite` (default): skip has-signal packets (~0% overhead). `standard`: signal injection for all count==1 dispatches, skip graph replay. `full`: profile everything including graph replay (requires ROCm 7.13+). |
 | `RTL_DEBUG` | `1` | Log per-call summary: intercept call count, device ID, batch skip decisions |
 | `RTL_DEBUG` | `2` | Log per-packet details: AQL type, signal handle, kernel object address |

--- a/rocm_trace_lite/cli.py
+++ b/rocm_trace_lite/cli.py
@@ -15,10 +15,10 @@ def main():
     # trace
     trace_p = sub.add_parser("trace", help="Trace a workload")
     trace_p.add_argument("-o", "--output", default="trace.db", help="Output trace file (default: trace.db)")
-    trace_p.add_argument("-m", "--mode", choices=["lite", "default", "full"], default=None,
+    trace_p.add_argument("-m", "--mode", choices=["lite", "standard", "full"], default=None,
                          help="Profiling mode: "
                               "lite (~0%% overhead, skip has-signal packets, safe for all ROCm, default), "
-                              "default (GPU timing for all count==1 dispatches, skip graph replay), "
+                              "standard (GPU timing for all count==1 dispatches, skip graph replay), "
                               "full (profile everything including graph replay, requires ROCm 7.13+)")
     trace_p.add_argument("cmd", nargs=argparse.REMAINDER, help="Command to trace")
 

--- a/rocm_trace_lite/cli.py
+++ b/rocm_trace_lite/cli.py
@@ -15,11 +15,12 @@ def main():
     # trace
     trace_p = sub.add_parser("trace", help="Trace a workload")
     trace_p.add_argument("-o", "--output", default="trace.db", help="Output trace file (default: trace.db)")
-    trace_p.add_argument("-m", "--mode", choices=["lite", "standard", "full"], default=None,
+    trace_p.add_argument("-m", "--mode", choices=["lite", "standard", "default", "full"], default=None,
                          help="Profiling mode: "
                               "lite (~0%% overhead, skip has-signal packets, safe for all ROCm, default), "
                               "standard (GPU timing for all count==1 dispatches, skip graph replay), "
-                              "full (profile everything including graph replay, requires ROCm 7.13+)")
+                              "full (profile everything including graph replay, requires ROCm 7.13+). "
+                              "'default' is accepted as alias for 'standard'.")
     trace_p.add_argument("cmd", nargs=argparse.REMAINDER, help="Command to trace")
 
     # convert

--- a/src/hsa_intercept.cpp
+++ b/src/hsa_intercept.cpp
@@ -73,7 +73,7 @@ static bool g_intercept_available = false;
 //   "standard" — signal injection + GPU timing for all count==1 dispatches, skip graph replay
 //   "full"     — profile everything including graph replay batches. Requires ROCm 7.13+
 //                with ROCR fix (rocm-systems commit 559d48b1). Will crash on ROCm <= 7.2.
-enum class RtlMode { STANDARD, LITE, FULL };
+enum class RtlMode { STANDARD = 0, LITE = 1, FULL = 2 };
 static RtlMode g_rtl_mode = RtlMode::LITE;
 
 // ---- Lock-free signal pool (Vyukov MPMC bounded ring buffer) ----

--- a/src/hsa_intercept.cpp
+++ b/src/hsa_intercept.cpp
@@ -69,12 +69,12 @@ static std::atomic<uint64_t> g_dispatch_id{0};
 static bool g_intercept_available = false;
 
 // RTL_MODE controls profiling behavior:
-//   (default) — signal injection + GPU timing, skip graph replay batches
-//   "lite"    — like default but also skip packets with existing completion_signal (~0% overhead)
-//   "full"    — profile everything including graph replay batches. Requires ROCm 7.13+
-//               with ROCR fix (rocm-systems commit 559d48b1). Will crash on ROCm <= 7.2.
-enum class RtlMode { DEFAULT, LITE, FULL };
-static RtlMode g_rtl_mode = RtlMode::LITE;  // safe default for ROCm <= 7.2 (avoids ROCR staging_buffer overflow)
+//   "lite"     — skip packets with existing completion_signal (~0% overhead). Default.
+//   "standard" — signal injection + GPU timing for all count==1 dispatches, skip graph replay
+//   "full"     — profile everything including graph replay batches. Requires ROCm 7.13+
+//                with ROCR fix (rocm-systems commit 559d48b1). Will crash on ROCm <= 7.2.
+enum class RtlMode { STANDARD, LITE, FULL };
+static RtlMode g_rtl_mode = RtlMode::LITE;
 
 // ---- Lock-free signal pool (Vyukov MPMC bounded ring buffer) ----
 // Replaces mutex + vector to eliminate contention on the per-dispatch hot path.
@@ -736,8 +736,8 @@ extern "C" bool OnLoad(void* pTable,
     if (mode_env) {
         if (strcmp(mode_env, "lite") == 0) {
             g_rtl_mode = RtlMode::LITE;
-        } else if (strcmp(mode_env, "default") == 0) {
-            g_rtl_mode = RtlMode::DEFAULT;
+        } else if (strcmp(mode_env, "standard") == 0 || strcmp(mode_env, "default") == 0) {
+            g_rtl_mode = RtlMode::STANDARD;
         } else if (strcmp(mode_env, "full") == 0) {
             g_rtl_mode = RtlMode::FULL;
         } else {
@@ -745,7 +745,7 @@ extern "C" bool OnLoad(void* pTable,
         }
     }
 
-    static const char* mode_names[] = {"default", "lite", "full"};
+    static const char* mode_names[] = {"standard", "lite", "full"};
     fprintf(stderr, "rtl: mode=%s\n", mode_names[(int)g_rtl_mode]);
 
     // Probe: check if hsa_amd_queue_intercept_create is functional.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ class TestCLIHelp:
         assert "standard" in out
         assert "lite" in out
         assert "full" in out
+        assert "default" in out  # accepted as alias for standard
 
     def test_convert_help(self):
         rc, out, _ = _run_cli("convert", "--help")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,7 +77,7 @@ class TestCLIHelp:
         rc, out, _ = _run_cli("trace", "--help")
         assert rc == 0
         assert "--mode" in out or "-m" in out
-        assert "default" in out
+        assert "standard" in out
         assert "lite" in out
         assert "full" in out
 

--- a/tests/test_gpu_hip.py
+++ b/tests/test_gpu_hip.py
@@ -408,7 +408,7 @@ class TestHipGraph:
 @skip_no_workload
 @skip_no_lib
 class TestRtlModes:
-    """GPU E2E tests for RTL_MODE=default/lite/full."""
+    """GPU E2E tests for RTL_MODE=lite/standard/full."""
 
     def _trace_with_mode(self, tmp_path, mode, workload_args, timeout=60):
         """Run gpu_workload under rtl trace with a specific mode."""

--- a/tests/test_hipgraph_safety.py
+++ b/tests/test_hipgraph_safety.py
@@ -156,7 +156,7 @@ class TestSignalForwarding:
 
 
 class TestRtlModes:
-    """Verify RTL_MODE profiling modes (default/lite/full)."""
+    """Verify RTL_MODE profiling modes (lite/standard/full)."""
 
     def _get_source(self):
         with open(HSA_FILE) as f:
@@ -169,10 +169,10 @@ class TestRtlModes:
         return match.group()
 
     def test_rtl_mode_enum_defined(self):
-        """RtlMode enum must define DEFAULT, LITE, FULL."""
+        """RtlMode enum must define STANDARD, LITE, FULL."""
         src = self._get_source()
         assert "RtlMode" in src, "No RtlMode enum"
-        assert "DEFAULT" in src, "No DEFAULT mode"
+        assert "STANDARD" in src, "No STANDARD mode"
         assert "LITE" in src, "No LITE mode"
         assert "FULL" in src, "No FULL mode"
 
@@ -190,7 +190,7 @@ class TestRtlModes:
     def test_mode_names_printed(self):
         """Mode name must be printed at startup."""
         src = self._get_source()
-        assert 'mode_names' in src and '"default"' in src and '"lite"' in src and '"full"' in src, \
+        assert 'mode_names' in src and '"standard"' in src and '"lite"' in src and '"full"' in src, \
             "Mode names not defined for printing"
 
     def test_lite_mode_skips_has_signal(self):


### PR DESCRIPTION
The mode named default conflicted with lite being the actual default mode. The README showed both lite (default) and a separate row called default in the profiling modes table.

Changes:
- CLI: --mode standard (was --mode default)
- Env var: RTL_MODE=standard (RTL_MODE=default still accepted for backward compat)
- Code: RtlMode::STANDARD (was RtlMode::DEFAULT)
- README, cli_reference.md, 4 test files updated