### PR TITLE
chore: bump version to v0.3.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.3.6
+
+### Bug fixes
+- **Preserve `dispatch_info` during multi-process merge (#91)**: `_merge_traces()` now selects and inserts the `completionSignal` column so per-op `hwq`/`wg`/`grid` metadata survives merging across processes.
+- **HWQ-based Perfetto tracks (#91)**: `rtl convert` groups GPU ops by hardware queue address (`HWQ 0x…`) when `dispatch_info` is present, giving a clearer view of actual GPU scheduling. Falls back to queue-based tracks when no `dispatch_info` is recorded (backward compatible).
+
+### Changes
+- **Rename profiling mode `default` → `standard` (#92)**: The name `default` conflicted with `lite` being the actual default when `--mode` is unspecified. CLI flag is now `--mode standard`; `RTL_MODE=default` is still accepted for backward compatibility.
+
 ## v0.3.5
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocm-trace-lite"
-version = "0.3.5"
+version = "0.3.6"
 description = "Self-contained GPU kernel profiler for ROCm. Zero roctracer dependency."
 license = {text = "MIT"}
 requires-python = ">=3.8"

--- a/rocm_trace_lite/__init__.py
+++ b/rocm_trace_lite/__init__.py
@@ -1,6 +1,6 @@
 """rocm-trace-lite: Self-contained GPU kernel profiler for ROCm."""
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 
 def get_lib_path() -> str:


### PR DESCRIPTION
## Summary

Release **v0.3.6** — rolls up three changes landed on `main` since `v0.3.5`:

- **#91** (fix): preserve `dispatch_info` during multi-process merge; group Perfetto tracks by HWQ address with queue-based fallback
- **#92** (change): rename profiling mode `default` → `standard` (RTL_MODE=default kept for back-compat)
- Skill config update (5fdc28e)

## Changes in this PR

- `pyproject.toml`: 0.3.5 → 0.3.6
- `rocm_trace_lite/__init__.py`: 0.3.5 → 0.3.6
- `docs/changelog.md`: new `v0.3.6` entry

## Test plan

- [x] `python3 -m pytest tests/ -v --tb=short` → **250 passed** (incl. `test_version_consistency`)
- [x] `ruff check pyproject.toml rocm_trace_lite/` → all checks passed
- [x] E2E perf regression vs main: paired mean delta **+0.72% ± 2.18%** across 9 interleaved rounds on MI355X (10k GPU ops; well within 5% CI threshold)
- [ ] On merge → tag `v0.3.6` will be pushed to trigger `release.yml` (wheel build in ROCm 7.2 container + GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)