### PR TITLE
Add tagging for kernels to roctx op annotation attribution

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## v0.3.7
 
 ### New features
+- **roctx op tagging**: New `rocpd_op.roctxId` column tags each GPU op with the correlation ID of its enclosing `roctxRangePush`/`Pop` range, captured at dispatch time on the launching host thread. Kernels join directly to their marker row (`kernel.roctxId = marker.roctxId`), enabling exact kernel→range attribution instead of fragile timing-based bucketing. Defaults to `0` when no range is active, backward compatible.
 - **TraceLens integration (#99)**: `rtl convert --format rocprofv3` emits rocprofiler-sdk-tool JSON that TraceLens can consume directly. Enables the pipeline: RTL (collect) → TraceLens (analyze) → Hyperloom (decide). Validated E2E on GPT-OSS 120B TP=8.
 - **HIP API interception (#94, RFC-003)**: `RTL_MODE=hip` with `LD_PRELOAD` captures CPU-side HIP API call timings (21 functions) alongside GPU kernel execution. Zero upstream dependency — uses `dlsym(RTLD_NEXT)` interposition. Re-entrancy safe, disabled by default, <1% overhead on serving workloads.
 

--- a/src/hsa_intercept.cpp
+++ b/src/hsa_intercept.cpp
@@ -185,6 +185,7 @@ struct DispatchData {
     uint64_t hw_queue_addr;         // HW queue base_address
     uint16_t wg_x, wg_y, wg_z;     // workgroup size from AQL packet
     uint32_t grid_x, grid_y, grid_z; // grid size from AQL packet
+    uint64_t roctx_id;              // enclosing roctx range (host thread)
 };
 
 static std::mutex g_work_mutex;
@@ -263,7 +264,7 @@ static void completion_worker() {
                      dd->grid_x, dd->grid_y, dd->grid_z);
             get_trace_db().record_kernel(name.c_str(), dd->device_id, dd->queue_id,
                                           time.start, time.end, dd->correlation_id,
-                                          dispatch_info);
+                                          dispatch_info, dd->roctx_id);
             g_recorded_ok.fetch_add(1, std::memory_order_relaxed);
         }
 
@@ -508,6 +509,7 @@ static void queue_intercept_cb(const void* in_packets, uint64_t count,
         auto* dd = new DispatchData;
         dd->dispatch_id = g_dispatch_id.fetch_add(1, std::memory_order_relaxed);
         dd->correlation_id = next_correlation_id();
+        dd->roctx_id = trace_db::current_roctx_id();
         dd->kernel_object = pkt->kernel_object;
         dd->device_id = qi->device_id;
         dd->queue_id = qi->queue_handle;

--- a/src/roctx_shim.cpp
+++ b/src/roctx_shim.cpp
@@ -80,3 +80,10 @@ int roctxRangePush(const char* message) { return roctxRangePushA(message); }
 uint64_t roctxRangeStart(const char* message) { return roctxRangeStartA(message); }
 
 } // extern "C"
+
+namespace trace_db {
+// current_roctx_id — innermost active push/pop range on this thread (0 if none)
+uint64_t current_roctx_id() {
+    return tls_roctx_stack.empty() ? 0 : tls_roctx_stack.back().correlation_id;
+}
+} // namespace trace_db

--- a/src/trace_db.cpp
+++ b/src/trace_db.cpp
@@ -86,7 +86,8 @@ CREATE TABLE IF NOT EXISTS rocpd_op (
     start INTEGER,
     end INTEGER,
     description_id INTEGER REFERENCES rocpd_string(id),
-    opType_id INTEGER REFERENCES rocpd_string(id)
+    opType_id INTEGER REFERENCES rocpd_string(id),
+    roctxId INTEGER DEFAULT 0
 );
 CREATE TABLE IF NOT EXISTS rocpd_api (
     id INTEGER PRIMARY KEY,
@@ -215,10 +216,10 @@ bool TraceDB::open(const std::string& filename) {
                  &stmt_kernel_, "api_insert"))
         return false;
 
-    if (!prepare("INSERT INTO rocpd_op(gpuId,queueId,sequenceId,completionSignal,start,end,description_id,opType_id) "
+    if (!prepare("INSERT INTO rocpd_op(gpuId,queueId,sequenceId,completionSignal,start,end,description_id,opType_id,roctxId) "
                  "VALUES(?1,?2,0,?7,?3,?4,"
                  "(SELECT id FROM rocpd_string WHERE string=?5),"
-                 "(SELECT id FROM rocpd_string WHERE string=?6))",
+                 "(SELECT id FROM rocpd_string WHERE string=?6),?8)",
                  &stmt_copy_, "op_insert"))
         return false;
 
@@ -308,7 +309,7 @@ void TraceDB::record_hip_api(const char* name, const char* args,
 void TraceDB::record_kernel(const char* name, int device_id, uint64_t queue_id,
                              uint64_t start_ns, uint64_t end_ns,
                              uint64_t correlation_id,
-                             const char* dispatch_info) {
+                             const char* dispatch_info, uint64_t roctx_id) {
     std::lock_guard<std::mutex> lock(g_db_mutex);
     if (!db_) return;
 
@@ -327,6 +328,7 @@ void TraceDB::record_kernel(const char* name, int device_id, uint64_t queue_id,
     } else {
         sqlite3_bind_null(stmt_copy_, 7);
     }
+    sqlite3_bind_int64(stmt_copy_, 8, (sqlite3_int64)roctx_id);
     if (step_ok(stmt_copy_)) { ++records_written_; } else { ++records_dropped_; }
 
     if (++batch_count_ >= 1000) {
@@ -354,6 +356,7 @@ void TraceDB::record_copy(int src_device, int dst_device, size_t bytes,
     sqlite3_bind_text(stmt_copy_, 5, desc, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt_copy_, 6, "CopyDeviceToDevice", -1, SQLITE_STATIC);
     sqlite3_bind_null(stmt_copy_, 7);
+    sqlite3_bind_int64(stmt_copy_, 8, 0);
     if (step_ok(stmt_copy_)) { ++records_written_; } else { ++records_dropped_; }
 
     if (++batch_count_ >= 1000) {
@@ -378,6 +381,7 @@ void TraceDB::record_roctx(const char* message, uint64_t start_ns, uint64_t dura
     sqlite3_bind_text(stmt_copy_, 5, message, -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt_copy_, 6, "UserMarker", -1, SQLITE_STATIC);
     sqlite3_bind_null(stmt_copy_, 7);
+    sqlite3_bind_int64(stmt_copy_, 8, (sqlite3_int64)correlation_id);
     if (step_ok(stmt_copy_)) { ++records_written_; } else { ++records_dropped_; }
 
     if (++batch_count_ >= 1000) {

--- a/src/trace_db.h
+++ b/src/trace_db.h
@@ -37,7 +37,8 @@ public:
     void record_kernel(const char* name, int device_id, uint64_t queue_id,
                        uint64_t start_ns, uint64_t end_ns,
                        uint64_t correlation_id,
-                       const char* dispatch_info = nullptr);
+                       const char* dispatch_info = nullptr,
+                       uint64_t roctx_id = 0);
 
     // Record a GPU memory copy (device-side)
     void record_copy(int src_device, int dst_device, size_t bytes,
@@ -74,5 +75,8 @@ bool is_trace_ready();
 
 // Global correlation ID counter
 uint64_t next_correlation_id();
+
+// Innermost roctx range active on the calling thread (0 if none)
+uint64_t current_roctx_id();
 
 } // namespace trace_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS rocpd_op (
     start INTEGER,
     end INTEGER,
     description_id INTEGER REFERENCES rocpd_string(id),
-    opType_id INTEGER REFERENCES rocpd_string(id)
+    opType_id INTEGER REFERENCES rocpd_string(id),
+    roctxId INTEGER DEFAULT 0
 );
 CREATE TABLE IF NOT EXISTS rocpd_api (
     id INTEGER PRIMARY KEY,

--- a/tests/test_roctx_id.py
+++ b/tests/test_roctx_id.py
@@ -29,9 +29,11 @@ def _populate_roctx_trace(path):
     op(-1, "layer_1", "UserMarker", 2000, 3000, 200)
     t = 1000
     for _ in range(4):
-        op(0, "incr", "KernelExecution", t, t + 50, 100); t += 100   # tagged with layer_0's id
+        op(0, "incr", "KernelExecution", t, t + 50, 100)
+        t += 100   # tagged with layer_0's id
     for _ in range(2):
-        op(0, "dbl", "KernelExecution", t, t + 50, 200); t += 100    # tagged with layer_1's id
+        op(0, "dbl", "KernelExecution", t, t + 50, 200)
+        t += 100    # tagged with layer_1's id
     conn.commit()
     conn.close()
 

--- a/tests/test_roctx_id.py
+++ b/tests/test_roctx_id.py
@@ -1,0 +1,91 @@
+"""T-roctx — rocpd_op.roctxId column + roctx-range attribution.
+
+The op->roctx feature tags each GPU op with its enclosing roctx range's id (`roctxId`), and marker
+rows (gpuId<0) store their own id, so a kernel attributes to its range via
+`kernel.roctxId == marker.roctxId` -- no timestamp bucketing. These tests use synthetic data that
+mirrors exactly what the patched tracer writes, so they run on CPU (no GPU) in CI.
+"""
+import sqlite3
+
+from conftest import SCHEMA_SQL
+
+
+def _populate_roctx_trace(path):
+    """Mirror the patched tracer's output: two marker rows whose roctxId is their own id, and
+    kernels tagged with the enclosing range's id. layer_0 (id=100): 4x incr; layer_1 (id=200): 2x dbl."""
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA_SQL)
+    for s in ("incr", "dbl", "layer_0", "layer_1", "KernelExecution", "UserMarker"):
+        conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES(?)", (s,))
+
+    def op(gpu, name, optype, start, end, roctx):
+        conn.execute(
+            "INSERT INTO rocpd_op(gpuId,queueId,sequenceId,start,end,description_id,opType_id,roctxId) "
+            "VALUES(?,?,0,?,?,(SELECT id FROM rocpd_string WHERE string=?),"
+            "(SELECT id FROM rocpd_string WHERE string=?),?)",
+            (gpu, 0, start, end, name, optype, roctx))
+
+    op(-1, "layer_0", "UserMarker", 1000, 2000, 100)   # marker stores its own id
+    op(-1, "layer_1", "UserMarker", 2000, 3000, 200)
+    t = 1000
+    for _ in range(4):
+        op(0, "incr", "KernelExecution", t, t + 50, 100); t += 100   # tagged with layer_0's id
+    for _ in range(2):
+        op(0, "dbl", "KernelExecution", t, t + 50, 200); t += 100    # tagged with layer_1's id
+    conn.commit()
+    conn.close()
+
+
+class TestRoctxIdColumn:
+    def test_rocpd_op_has_roctxid_column(self, tmp_rpd):
+        """The schema exposes the new roctxId column on rocpd_op."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(rocpd_op)")]
+        conn.close()
+        assert "roctxId" in cols, f"roctxId missing from rocpd_op: {cols}"
+
+    def test_default_roctxid_is_zero(self, tmp_rpd):
+        """An op inserted without roctxId defaults to 0 (back-compat: old inserts omit it)."""
+        conn = sqlite3.connect(tmp_rpd)
+        conn.executescript(SCHEMA_SQL)
+        conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES('k')")
+        conn.execute("INSERT OR IGNORE INTO rocpd_string(string) VALUES('KernelExecution')")
+        conn.execute(
+            "INSERT INTO rocpd_op(gpuId,queueId,sequenceId,start,end,description_id,opType_id) "
+            "VALUES(0,0,0,10,20,(SELECT id FROM rocpd_string WHERE string='k'),"
+            "(SELECT id FROM rocpd_string WHERE string='KernelExecution'))")
+        conn.commit()
+        val = conn.execute("SELECT roctxId FROM rocpd_op").fetchone()[0]
+        conn.close()
+        assert val == 0, f"expected default 0, got {val}"
+
+
+class TestRoctxAttribution:
+    def test_every_kernel_links_to_its_range(self, tmp_rpd):
+        """Each kernel joins to exactly its enclosing marker via roctxId, with the right region."""
+        _populate_roctx_trace(tmp_rpd)
+        conn = sqlite3.connect(tmp_rpd)
+        rows = conn.execute(
+            "SELECT ks.string, ms.string "
+            "FROM rocpd_op k JOIN rocpd_string ks ON k.description_id=ks.id "
+            "JOIN rocpd_op m ON m.roctxId=k.roctxId AND m.gpuId<0 "
+            "JOIN rocpd_string ms ON m.description_id=ms.id "
+            "WHERE k.gpuId>=0").fetchall()
+        conn.close()
+        assert len(rows) == 6, f"expected 6 linked kernels, got {len(rows)}"
+        expect = {"incr": "layer_0", "dbl": "layer_1"}
+        for kernel, region in rows:
+            assert region == expect[kernel], f"{kernel} -> {region}, expected {expect[kernel]}"
+
+    def test_attribution_counts(self, tmp_rpd):
+        """Per-range kernel counts match the ground truth."""
+        _populate_roctx_trace(tmp_rpd)
+        conn = sqlite3.connect(tmp_rpd)
+        counts = dict(conn.execute(
+            "SELECT ms.string, COUNT(*) "
+            "FROM rocpd_op k JOIN rocpd_op m ON m.roctxId=k.roctxId AND m.gpuId<0 "
+            "JOIN rocpd_string ms ON m.description_id=ms.id "
+            "WHERE k.gpuId>=0 GROUP BY ms.string").fetchall())
+        conn.close()
+        assert counts == {"layer_0": 4, "layer_1": 2}, counts


### PR DESCRIPTION
Adds ROCTx column linking GPU kernels to the roctx range that is concurrently active when they are dispatched. Kernels can directly join to the roctx-generated marker annotations (ex. prefill/decode indicating markers such as `execute_context_n(N)_generation_m(M)`) via their range id. 

This is useful because the current method of correlating kernels with the current marker depends purely on bucketing via timestamps, which is fragile and not provable to work for all edge cases such as slight timing mismatches. Additionally, the timing method works only with synchronize calls, which can be avoided through this.  

How: At dispatch (queue_intercept_cb, on the launching thread) we read the innermost range from the roctx push/pop stack and carry it through DispatchData to record_kernel, which writes it to the new column.

src changes:

roctx_shim.cpp: expose current_roctx_id() (top of the thread-local range stack).
hsa_intercept.cpp: capture it into DispatchData at dispatch and pass it to record_kernel.
trace_db.{h,cpp}: add the roctxId column, bind it in the op insert; markers store their own id, copies store 0.