### PR TITLE
ci: disable GPT-5.4 review until OpenAI billing is restored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,10 @@ jobs:
 
   ai-review:
     name: GPT-5.4 Code Review
-    if: github.event_name == 'pull_request'
+    # Disabled until the OpenAI account quota/billing is restored (429 insufficient_quota).
+    # Re-enable by setting repository variable ENABLE_AI_REVIEW=true
+    # (gh variable set ENABLE_AI_REVIEW --body true --repo sunway513/rocm-trace-lite).
+    if: github.event_name == 'pull_request' && vars.ENABLE_AI_REVIEW == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
OpenAI account is out of quota (429 insufficient_quota), so the review produces no output. Gate the `ai-review` job behind repo variable `ENABLE_AI_REVIEW`.

Re-enable with:
```
gh variable set ENABLE_AI_REVIEW --body true --repo sunway513/rocm-trace-lite
```
When disabled the job is simply skipped (neutral, non-blocking).